### PR TITLE
removes import to RxTests in the playground page

### DIFF
--- a/Demo/RxSwiftExtDemo/RxSwiftExtPlayground.playground/Pages/retryWithBehavior.xcplaygroundpage/Contents.swift
+++ b/Demo/RxSwiftExtDemo/RxSwiftExtPlayground.playground/Pages/retryWithBehavior.xcplaygroundpage/Contents.swift
@@ -11,7 +11,6 @@
 import Foundation
 import RxSwift
 import RxSwiftExt
-import RxTests
 
 private enum SampleErrors : ErrorType {
 	case fatalError


### PR DESCRIPTION
RxTest isn't included in the main target, so playground page doesn't compile. this PR removes the import