### PR TITLE
Repeat on complete

### DIFF
--- a/Demo/RxSwiftExtDemo.xcodeproj/project.pbxproj
+++ b/Demo/RxSwiftExtDemo.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		8458AF191CDA679600E6F2FE /* DistinctTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8458AF181CDA679600E6F2FE /* DistinctTests.swift */; };
 		8458AF1F1CDA74A000E6F2FE /* WeakTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32141ADA1CC4129600569FFA /* WeakTests.swift */; };
 		8458AF201CDA74A000E6F2FE /* WeakTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32141ADD1CC4B9F300569FFA /* WeakTarget.swift */; };
+		9C072FDD1D5519690092EFA1 /* repeatWithBehaviorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C072FDC1D5519690092EFA1 /* repeatWithBehaviorTests.swift */; };
 		9C1F54FA1CB67017001421F2 /* RxSwiftExtDemo.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C1F54F91CB67017001421F2 /* RxSwiftExtDemo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9C1F55021CB67026001421F2 /* Podfile in Resources */ = {isa = PBXBuildFile; fileRef = 9C1F55011CB67026001421F2 /* Podfile */; };
 		9C1F552F1CB674B0001421F2 /* UnwrapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C1F552E1CB674B0001421F2 /* UnwrapTests.swift */; };
@@ -54,6 +55,7 @@
 		6EC6851E1D3BCEFC0051C188 /* RetryWithBehaviorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RetryWithBehaviorTests.swift; sourceTree = "<group>"; };
 		80211527B45BAEA1EC93FFC5 /* Pods-RxSwiftExtDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RxSwiftExtDemo.debug.xcconfig"; path = "Pods/Target Support Files/Pods-RxSwiftExtDemo/Pods-RxSwiftExtDemo.debug.xcconfig"; sourceTree = "<group>"; };
 		8458AF181CDA679600E6F2FE /* DistinctTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DistinctTests.swift; sourceTree = "<group>"; };
+		9C072FDC1D5519690092EFA1 /* repeatWithBehaviorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = repeatWithBehaviorTests.swift; sourceTree = "<group>"; };
 		9C1F54F61CB67017001421F2 /* RxSwiftExtDemo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxSwiftExtDemo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9C1F54F91CB67017001421F2 /* RxSwiftExtDemo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RxSwiftExtDemo.h; sourceTree = "<group>"; };
 		9C1F54FB1CB67017001421F2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -143,6 +145,7 @@
 				3DC705A91CBCF74100493BB2 /* OnceTests.swift */,
 				9C1F552E1CB674B0001421F2 /* UnwrapTests.swift */,
 				6EC6851E1D3BCEFC0051C188 /* RetryWithBehaviorTests.swift */,
+				9C072FDC1D5519690092EFA1 /* repeatWithBehaviorTests.swift */,
 				3D9AB9401D4E04C4003800C4 /* catchErrorJustCompleteTests.swift */,
 				9C1F55301CB674B0001421F2 /* Info.plist */,
 			);
@@ -372,6 +375,7 @@
 				3D3E95BB1CC01A150013FC08 /* ignoreWhenTests.swift in Sources */,
 				3DC705AA1CBCF74100493BB2 /* OnceTests.swift in Sources */,
 				3DB4B1EE1CC43D940006B332 /* cascadeTests.swift in Sources */,
+				9C072FDD1D5519690092EFA1 /* repeatWithBehaviorTests.swift in Sources */,
 				3D3EA4961CBAFEE800EB90DB /* IgnoreTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Demo/RxSwiftExtDemo/RxSwiftExtPlayground.playground/Pages/Index.xcplaygroundpage/Contents.swift
+++ b/Demo/RxSwiftExtDemo/RxSwiftExtPlayground.playground/Pages/Index.xcplaygroundpage/Contents.swift
@@ -28,6 +28,7 @@
  1. [Observable.cascade([Observable])](cascade) contructor, takes a ordinary sequence (i.e. Array) of observables and cascades through them
  1. [distinct()](distinct) operator, suppress duplicate items emitted by an Observable
  1. [retryWithBehavior()](retryWithBehavior) operator, retry on error with various delay / predicate options
+ 1. [repeatWithBehavior()](retryWithBehavior) operator, repeat on completion with various delay / predicate options
  1. [catchErrorJustComplete()](catchErrorJustComplete) ignore any error and complete the sequence instead
  */
 

--- a/Demo/RxSwiftExtDemo/RxSwiftExtPlayground.playground/Pages/repeatWithBehavior.xcplaygroundpage/Contents.swift
+++ b/Demo/RxSwiftExtDemo/RxSwiftExtPlayground.playground/Pages/repeatWithBehavior.xcplaygroundpage/Contents.swift
@@ -16,7 +16,7 @@ private enum SampleErrors : ErrorType {
     case fatalError
 }
 
-let completedObservable = Observable<String>.create { observer in
+let completingObservable = Observable<String>.create { observer in
     observer.onNext("First")
     observer.onNext("Second")
     observer.onCompleted()
@@ -32,35 +32,29 @@ let erroringObservable = Observable<String>.create { observer in
 
 let delayScheduler = SerialDispatchQueueScheduler(globalConcurrentQueueQOS: .Utility)
 
-example("Immediate retry") {
-    // after receiving error will immediate retry
-    _ = completedObservable.retry(.Immediate(maxAttemptCount: 3))
+example("Immediate repeat") {
+    // repeat immediately after completion
+    _ = completingObservable.repeatWithBehavior(.Immediate(maxCount: 2))
         .subscribeNext { event in
             print("Receive event: \(event)")
     }
 }
 
-example("Immediate retry with custom predicate") {
+
+
+example("Immediate repeat with custom predicate") {
     // in this case we provide custom predicate, that will evaluate error and decide, should we retry or not
-    _ = sampleObservable.retry(.Immediate(maxAttemptCount: 3), scheduler: delayScheduler) { error in
-        // error checks here
-        // in this example we simply say, that retry not allowed
-        return false
-        }
-        .doOnError { error in
-            print("Receive error \(error)")
+    _ = completingObservable.repeatWithBehavior(.Immediate(maxCount: 2), scheduler: delayScheduler) {
+            return true
         }
         .subscribeNext { event in
             print("Receive event: \(event)")
     }
 }
 
-example("Delayed retry") {
+example("Delayed repeat") {
     // after error, observable will be retried after 1.0 second delay
-    _ = sampleObservable.retry(.Delayed(maxAttemptCount: 3, time: 1.0), scheduler: delayScheduler)
-        .doOnError { error in
-            print("Receive error: \(error)")
-        }
+    _ = completingObservable.repeatWithBehavior(.Delayed(maxCount: 2, time: 1.0), scheduler: delayScheduler)
         .subscribeNext { event in
             print("Receive event: \(event)")
     }
@@ -73,10 +67,7 @@ example("Exponential delay") {
     // in case of an error initial delay will be 1 second,
     // every next delay will be doubled
     // delay formula is: initial * pow(1 + multiplier, Double(currentAttempt - 1)), so multiplier 1.0 means, delay will doubled
-    _ = sampleObservable.retry(.ExponentialDelayed(maxAttemptCount: 3, initial: 1.0, multiplier: 1.0), scheduler: delayScheduler)
-        .doOnError { error in
-            print("Receive error: \(error)")
-        }
+    _ = completingObservable.repeatWithBehavior(.ExponentialDelayed(maxCount: 3, initial: 1.0, multiplier: 1.2), scheduler: delayScheduler)
         .subscribeNext { event in
             print("Receive event: \(event)")
     }
@@ -87,21 +78,31 @@ NSThread.sleepForTimeInterval(4.0)
 
 example("Delay with calculator") {
     // custom delay calculator
-    // will be invoked to calculate delay for particular attempt
-    // will be invoked in the beginning of attempt, not when error occurred
-    let customCalculator: (UInt -> Double) = { attempt in
+    // will be invoked to calculate delay for particular repeat
+    // will be invoked in the beginning of repeat
+    let customCalculator: (UInt) -> Double = { attempt in
         switch attempt {
         case 1: return 0.5
         case 2: return 1.5
         default: return 2.0
         }
     }
-    _ = sampleObservable.retry(.CustomTimerDelayed(maxAttemptCount: 3, delayCalculator: customCalculator), scheduler: delayScheduler)
-        .doOnError { error in
-            print("Receive error: \(error)")
+    _ = completingObservable.repeatWithBehavior(.CustomTimerDelayed(maxCount: 3, delayCalculator: customCalculator), scheduler: delayScheduler)
+        .subscribeNext { event in
+            print("Receive event: \(event)")
+    }
+}
+
+// sleep in order to wait until previous example finishes
+NSThread.sleepForTimeInterval(4.0)
+
+example("Observable with error") {
+    _ = erroringObservable.repeatWithBehavior(.Immediate(maxCount: 2))
+        .doOnError {error in
+            print("Repetition interrupted with error: \(error)")
         }
         .subscribeNext { event in
-            print("1Receive event: \(event)")
+            print("Receive event: \(event)")
     }
 }
 

--- a/Demo/RxSwiftExtDemo/RxSwiftExtPlayground.playground/Pages/repeatWithBehavior.xcplaygroundpage/Contents.swift
+++ b/Demo/RxSwiftExtDemo/RxSwiftExtPlayground.playground/Pages/repeatWithBehavior.xcplaygroundpage/Contents.swift
@@ -1,0 +1,110 @@
+/*:
+ > # IMPORTANT: To use `RxSwiftExtPlayground.playground`, please:
+
+ 1. Build `RxSwiftExt` scheme for a simulator target
+ 1. Build `RxSwiftExtDemo` scheme for a simulator target
+ 1. Choose `View > Show Debug Area`
+ */
+
+//: [Previous](@previous)
+
+import Foundation
+import RxSwift
+import RxSwiftExt
+
+private enum SampleErrors : ErrorType {
+    case fatalError
+}
+
+let completedObservable = Observable<String>.create { observer in
+    observer.onNext("First")
+    observer.onNext("Second")
+    observer.onCompleted()
+    return NopDisposable.instance
+}
+
+let erroringObservable = Observable<String>.create { observer in
+    observer.onNext("First")
+    observer.onNext("Second")
+    observer.onError(SampleErrors.fatalError)
+    return NopDisposable.instance
+}
+
+let delayScheduler = SerialDispatchQueueScheduler(globalConcurrentQueueQOS: .Utility)
+
+example("Immediate retry") {
+    // after receiving error will immediate retry
+    _ = completedObservable.retry(.Immediate(maxAttemptCount: 3))
+        .subscribeNext { event in
+            print("Receive event: \(event)")
+    }
+}
+
+example("Immediate retry with custom predicate") {
+    // in this case we provide custom predicate, that will evaluate error and decide, should we retry or not
+    _ = sampleObservable.retry(.Immediate(maxAttemptCount: 3), scheduler: delayScheduler) { error in
+        // error checks here
+        // in this example we simply say, that retry not allowed
+        return false
+        }
+        .doOnError { error in
+            print("Receive error \(error)")
+        }
+        .subscribeNext { event in
+            print("Receive event: \(event)")
+    }
+}
+
+example("Delayed retry") {
+    // after error, observable will be retried after 1.0 second delay
+    _ = sampleObservable.retry(.Delayed(maxAttemptCount: 3, time: 1.0), scheduler: delayScheduler)
+        .doOnError { error in
+            print("Receive error: \(error)")
+        }
+        .subscribeNext { event in
+            print("Receive event: \(event)")
+    }
+}
+
+// sleep in order to wait until previous example finishes
+NSThread.sleepForTimeInterval(2.5)
+
+example("Exponential delay") {
+    // in case of an error initial delay will be 1 second,
+    // every next delay will be doubled
+    // delay formula is: initial * pow(1 + multiplier, Double(currentAttempt - 1)), so multiplier 1.0 means, delay will doubled
+    _ = sampleObservable.retry(.ExponentialDelayed(maxAttemptCount: 3, initial: 1.0, multiplier: 1.0), scheduler: delayScheduler)
+        .doOnError { error in
+            print("Receive error: \(error)")
+        }
+        .subscribeNext { event in
+            print("Receive event: \(event)")
+    }
+}
+
+// sleep in order to wait until previous example finishes
+NSThread.sleepForTimeInterval(4.0)
+
+example("Delay with calculator") {
+    // custom delay calculator
+    // will be invoked to calculate delay for particular attempt
+    // will be invoked in the beginning of attempt, not when error occurred
+    let customCalculator: (UInt -> Double) = { attempt in
+        switch attempt {
+        case 1: return 0.5
+        case 2: return 1.5
+        default: return 2.0
+        }
+    }
+    _ = sampleObservable.retry(.CustomTimerDelayed(maxAttemptCount: 3, delayCalculator: customCalculator), scheduler: delayScheduler)
+        .doOnError { error in
+            print("Receive error: \(error)")
+        }
+        .subscribeNext { event in
+            print("1Receive event: \(event)")
+    }
+}
+
+playgroundShouldContinueIndefinitely()
+
+//: [Next](@next)

--- a/Demo/RxSwiftExtDemo/RxSwiftExtPlayground.playground/Pages/retryWithBehavior.xcplaygroundpage/Contents.swift
+++ b/Demo/RxSwiftExtDemo/RxSwiftExtPlayground.playground/Pages/retryWithBehavior.xcplaygroundpage/Contents.swift
@@ -11,7 +11,6 @@
 import Foundation
 import RxSwift
 import RxSwiftExt
-import RxTests
 
 private enum SampleErrors : ErrorType {
 	case fatalError
@@ -29,7 +28,7 @@ let delayScheduler = SerialDispatchQueueScheduler(globalConcurrentQueueQOS: .Uti
 
 example("Immediate retry") {
 	// after receiving error will immediate retry
-	_ = sampleObservable.retry(.Immediate(maxAttemptCount: 3))
+	_ = sampleObservable.retry(.Immediate(maxCount: 3))
 		.doOnError { error in
 			print("Receive error \(error)")
 		}
@@ -40,7 +39,7 @@ example("Immediate retry") {
 
 example("Immediate retry with custom predicate") {
 	// in this case we provide custom predicate, that will evaluate error and decide, should we retry or not
-	_ = sampleObservable.retry(.Immediate(maxAttemptCount: 3), scheduler: delayScheduler) { error in
+	_ = sampleObservable.retry(.Immediate(maxCount: 3), scheduler: delayScheduler) { error in
 		// error checks here
 		// in this example we simply say, that retry not allowed
 		return false
@@ -55,7 +54,7 @@ example("Immediate retry with custom predicate") {
 
 example("Delayed retry") {
 	// after error, observable will be retried after 1.0 second delay
-	_ = sampleObservable.retry(.Delayed(maxAttemptCount: 3, time: 1.0), scheduler: delayScheduler)
+	_ = sampleObservable.retry(.Delayed(maxCount: 3, time: 1.0), scheduler: delayScheduler)
 		.doOnError { error in
 			print("Receive error: \(error)")
 		}
@@ -70,8 +69,8 @@ NSThread.sleepForTimeInterval(2.5)
 example("Exponential delay") {
 	// in case of an error initial delay will be 1 second,
 	// every next delay will be doubled
-	// delay formula is: initial * pow(1 + multiplier, Double(currentAttempt - 1)), so multiplier 1.0 means, delay will doubled
-	_ = sampleObservable.retry(.ExponentialDelayed(maxAttemptCount: 3, initial: 1.0, multiplier: 1.0), scheduler: delayScheduler)
+	// delay formula is: initial * pow(1 + multiplier, Double(currentRepetition - 1)), so multiplier 1.0 means, delay will doubled
+	_ = sampleObservable.retry(.ExponentialDelayed(maxCount: 3, initial: 1.0, multiplier: 1.0), scheduler: delayScheduler)
 		.doOnError { error in
 			print("Receive error: \(error)")
 		}
@@ -85,8 +84,8 @@ NSThread.sleepForTimeInterval(4.0)
 
 example("Delay with calculator") {
 	// custom delay calculator
-	// will be invoked to calculate delay for particular attempt
-	// will be invoked in the beginning of attempt, not when error occurred
+	// will be invoked to calculate delay for particular repetition
+	// will be invoked in the beginning of repetition, not when error occurred
 	let customCalculator: (UInt -> Double) = { attempt in
 		switch attempt {
 		case 1: return 0.5
@@ -94,7 +93,7 @@ example("Delay with calculator") {
 		default: return 2.0
 		}
 	}
-	_ = sampleObservable.retry(.CustomTimerDelayed(maxAttemptCount: 3, delayCalculator: customCalculator), scheduler: delayScheduler)
+	_ = sampleObservable.retry(.CustomTimerDelayed(maxCount: 3, delayCalculator: customCalculator), scheduler: delayScheduler)
 		.doOnError { error in
 			print("Receive error: \(error)")
 		}

--- a/Demo/RxSwiftExtDemo/RxSwiftExtPlayground.playground/contents.xcplayground
+++ b/Demo/RxSwiftExtDemo/RxSwiftExtPlayground.playground/contents.xcplayground
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='6.0' target-platform='ios' display-mode='raw' executeOnSourceChanges='false'>
+<playground version='6.0' target-platform='ios' display-mode='rendered' executeOnSourceChanges='false'>
     <pages>
         <page name='Index'/>
         <page name='unwrap'/>
@@ -10,6 +10,7 @@
         <page name='cascade'/>
         <page name='distinct'/>
         <page name='retryWithBehavior'/>
+        <page name='repeatWithBehavior'/>
         <page name='catchErrorJustComplete'/>
     </pages>
 </playground>

--- a/Demo/RxSwiftExtDemoTests/RetryWithBehaviorTests.swift
+++ b/Demo/RxSwiftExtDemoTests/RetryWithBehaviorTests.swift
@@ -66,7 +66,7 @@ class RetryWithBehaviorTests: XCTestCase {
 			error(690, RepeatTestErrors.fatalError)]
 		
 		let res = scheduler.start(0, subscribed: 0, disposed: 1000) { () -> Observable<Int> in
-			return self.sampleValues.asObservable().retry(.Immediate(maxAttemptCount: 3), scheduler: self.scheduler)
+			return self.sampleValues.asObservable().retry(.Immediate(maxCount: 3), scheduler: self.scheduler)
 		}
 		
 		XCTAssertEqual(res.events, correctValues)
@@ -78,7 +78,7 @@ class RetryWithBehaviorTests: XCTestCase {
         ]
         
         let res = scheduler.start(0, subscribed: 0, disposed: 1000) { () -> Observable<Int> in
-            return self.sampleValuesImmediateError.asObservable().retry(.Immediate(maxAttemptCount: 3), scheduler: self.scheduler)
+            return self.sampleValuesImmediateError.asObservable().retry(.Immediate(maxCount: 3), scheduler: self.scheduler)
         }
         
         XCTAssertEqual(res.events, correctValues)
@@ -96,7 +96,7 @@ class RetryWithBehaviorTests: XCTestCase {
         ]
         
         let res = scheduler.start(0, subscribed: 0, disposed: 1000) { () -> Observable<Int> in
-            return self.sampleValuesNeverError.asObservable().retry(.Immediate(maxAttemptCount: 3), scheduler: self.scheduler)
+            return self.sampleValuesNeverError.asObservable().retry(.Immediate(maxCount: 3), scheduler: self.scheduler)
         }
         
         XCTAssertEqual(res.events, correctValues)
@@ -114,7 +114,7 @@ class RetryWithBehaviorTests: XCTestCase {
 		
 		// provide simple predicate that always return true
 		let res = scheduler.start(0, subscribed: 0, disposed: 1000) { () -> Observable<Int> in
-			return self.sampleValues.asObservable().retry(.Immediate(maxAttemptCount: 3), scheduler: self.scheduler) { _ in
+			return self.sampleValues.asObservable().retry(.Immediate(maxCount: 3), scheduler: self.scheduler) { _ in
 				return true
 			}
 		}
@@ -133,7 +133,7 @@ class RetryWithBehaviorTests: XCTestCase {
         // provide simple predicate that always return true
         var attempts = 0
         let res = scheduler.start(0, subscribed: 0, disposed: 1000) { () -> Observable<Int> in
-            return self.sampleValues.asObservable().retry(.Immediate(maxAttemptCount: 3), scheduler: self.scheduler) { _ in
+            return self.sampleValues.asObservable().retry(.Immediate(maxCount: 3), scheduler: self.scheduler) { _ in
                 attempts += 1
                 return attempts == 1
             }
@@ -150,7 +150,7 @@ class RetryWithBehaviorTests: XCTestCase {
 		
 		// provide simple predicate that always return false (so, sequence will not repeated)
 		let res = scheduler.start(0, subscribed: 0, disposed: 1000) { () -> Observable<Int> in
-			return self.sampleValues.asObservable().retry(.Immediate(maxAttemptCount: 3), scheduler: self.scheduler) { _ in
+			return self.sampleValues.asObservable().retry(.Immediate(maxCount: 3), scheduler: self.scheduler) { _ in
 				return false
 			}
 		}
@@ -169,7 +169,7 @@ class RetryWithBehaviorTests: XCTestCase {
 			error(700, RepeatTestErrors.fatalError)]
 		
 		let res = scheduler.start(0, subscribed: 0, disposed: 1000) { () -> Observable<Int> in
-			return self.sampleValues.asObservable().retry(.Delayed(maxAttemptCount: 3, time: 5.0), scheduler: self.scheduler)
+			return self.sampleValues.asObservable().retry(.Delayed(maxCount: 3, time: 5.0), scheduler: self.scheduler)
 		}
 		
 		XCTAssertEqual(res.events, correctValues)
@@ -186,7 +186,7 @@ class RetryWithBehaviorTests: XCTestCase {
 			error(700, RepeatTestErrors.fatalError)]
 		
 		let res = scheduler.start(0, subscribed: 0, disposed: 1000) { () -> Observable<Int> in
-			return self.sampleValues.asObservable().retry(.Delayed(maxAttemptCount: 3, time: 5.0), scheduler: self.scheduler) { _ in
+			return self.sampleValues.asObservable().retry(.Delayed(maxCount: 3, time: 5.0), scheduler: self.scheduler) { _ in
 				return true
 			}
 		}
@@ -201,7 +201,7 @@ class RetryWithBehaviorTests: XCTestCase {
 			error(230, RepeatTestErrors.fatalError)]
 		
 		let res = scheduler.start(0, subscribed: 0, disposed: 1000) { () -> Observable<Int> in
-			return self.sampleValues.asObservable().retry(.Delayed(maxAttemptCount: 3, time: 5.0), scheduler: self.scheduler) { _ in
+			return self.sampleValues.asObservable().retry(.Delayed(maxCount: 3, time: 5.0), scheduler: self.scheduler) { _ in
 				return false
 			}
 		}
@@ -222,7 +222,7 @@ class RetryWithBehaviorTests: XCTestCase {
 			error(955, RepeatTestErrors.fatalError)]
 		
 		let res = scheduler.start(0, subscribed: 0, disposed: 1000) { () -> Observable<Int> in
-			return self.sampleValues.asObservable().retry(.ExponentialDelayed(maxAttemptCount: 4, initial: 5.0, multiplier: 1.0), scheduler: self.scheduler)
+			return self.sampleValues.asObservable().retry(.ExponentialDelayed(maxCount: 4, initial: 5.0, multiplier: 1.0), scheduler: self.scheduler)
 		}
 		
 		XCTAssertEqual(res.events, correctValues)
@@ -241,7 +241,7 @@ class RetryWithBehaviorTests: XCTestCase {
 			error(955, RepeatTestErrors.fatalError)]
 		
 		let res = scheduler.start(0, subscribed: 0, disposed: 1000) { () -> Observable<Int> in
-			return self.sampleValues.asObservable().retry(.ExponentialDelayed(maxAttemptCount: 4, initial: 5.0, multiplier: 1.0), scheduler: self.scheduler) { _ in
+			return self.sampleValues.asObservable().retry(.ExponentialDelayed(maxCount: 4, initial: 5.0, multiplier: 1.0), scheduler: self.scheduler) { _ in
 				return true
 			}
 		}
@@ -256,7 +256,7 @@ class RetryWithBehaviorTests: XCTestCase {
 			error(230, RepeatTestErrors.fatalError)]
 		
 		let res = scheduler.start(0, subscribed: 0, disposed: 1000) { () -> Observable<Int> in
-			return self.sampleValues.asObservable().retry(.ExponentialDelayed(maxAttemptCount: 4, initial: 5.0, multiplier: 1.0), scheduler: self.scheduler) { _ in
+			return self.sampleValues.asObservable().retry(.ExponentialDelayed(maxCount: 4, initial: 5.0, multiplier: 1.0), scheduler: self.scheduler) { _ in
 				return false
 			}
 		}
@@ -289,7 +289,7 @@ class RetryWithBehaviorTests: XCTestCase {
 				}
 			}
 			
-			return self.sampleValues.asObservable().retry(.CustomTimerDelayed(maxAttemptCount: 5, delayCalculator: customCalculator), scheduler: self.scheduler)
+			return self.sampleValues.asObservable().retry(.CustomTimerDelayed(maxCount: 5, delayCalculator: customCalculator), scheduler: self.scheduler)
 		}
 		
 		XCTAssertEqual(res.events, correctValues)
@@ -320,7 +320,7 @@ class RetryWithBehaviorTests: XCTestCase {
 				}
 			}
 			
-			return self.sampleValues.asObservable().retry(.CustomTimerDelayed(maxAttemptCount: 5, delayCalculator: customCalculator), scheduler: self.scheduler) { _ in
+			return self.sampleValues.asObservable().retry(.CustomTimerDelayed(maxCount: 5, delayCalculator: customCalculator), scheduler: self.scheduler) { _ in
 				return true
 			}
 		}
@@ -345,7 +345,7 @@ class RetryWithBehaviorTests: XCTestCase {
 				}
 			}
 			
-			return self.sampleValues.asObservable().retry(.CustomTimerDelayed(maxAttemptCount: 5, delayCalculator: customCalculator), scheduler: self.scheduler) { _ in
+			return self.sampleValues.asObservable().retry(.CustomTimerDelayed(maxCount: 5, delayCalculator: customCalculator), scheduler: self.scheduler) { _ in
 				return false
 			}
 		}

--- a/Demo/RxSwiftExtDemoTests/repeatWithBehaviorTests.swift
+++ b/Demo/RxSwiftExtDemoTests/repeatWithBehaviorTests.swift
@@ -1,0 +1,265 @@
+//
+//  RetryWithBehaviorTests.swift
+//  RxSwiftExtDemo
+//
+//  Created by Anton Efimenko on 17.07.16.
+//  Copyright © 2016 RxSwift Community. All rights reserved.
+//
+
+import XCTest
+import RxSwift
+import RxSwiftExt
+import RxTests
+
+private enum RepeatTestErrors : ErrorType {
+	case fatalError
+}
+
+class RepeatWithBehaviorTests: XCTestCase {
+	var sampleValues: TestableObservable<Int>!
+    var sampleValuesWithError: TestableObservable<Int>!
+	let scheduler = TestScheduler(initialClock: 0)
+	
+	override func setUp() {
+		super.setUp()
+
+		sampleValues = scheduler.createColdObservable([
+			next(210, 1),
+			next(220, 2),
+			completed(300)
+			])
+     
+        sampleValuesWithError = scheduler.createColdObservable([
+            next(210, 1),
+            error(220, RepeatTestErrors.fatalError),
+            ])
+	}
+
+    //MARK: correct event values
+    let immediateCorrectValues = [
+        next(210, 1),
+        next(220, 2),
+        next(510, 1),
+        next(520, 2),
+        completed(600)]
+
+    let customDelayCorrectValues = [
+        next(210, 1),
+        next(220, 2),
+        next(520, 1),
+        next(530, 2),
+        next(850, 1),
+        next(860, 2),
+        completed(940)]
+
+    let exponentialCorrectValues = [
+        next(210, 1),
+        next(220, 2),
+        next(512, 1),
+        next(522, 2),
+        next(818, 1),
+        next(828, 2),
+        completed(908)]
+
+    let erroredCorrectValues : [Recorded<Event<Int>>] = [
+        next(210, 1),
+        error(220, RepeatTestErrors.fatalError)
+    ]
+
+    //MARK: immediate repeats
+
+	func testImmediateRepeatWithoutPredicate() {
+		let res = scheduler.start(0, subscribed: 0, disposed: 1000) { () -> Observable<Int> in
+			return self.sampleValues.asObservable().repeatWithBehavior(.Immediate(maxCount: 2), scheduler: self.scheduler)
+		}
+		XCTAssertEqual(res.events, immediateCorrectValues)
+	}
+	
+    func testImmediateRepeatWithError() {
+        let res = scheduler.start(0, subscribed: 0, disposed: 1000) { () -> Observable<Int> in
+            return self.sampleValuesWithError.asObservable().repeatWithBehavior(.Immediate(maxCount: 3), scheduler: self.scheduler)
+        }
+        
+        XCTAssertEqual(res.events, erroredCorrectValues)
+    }
+
+	func testImmediateRepeatWithPredicate() {
+        var isRepeat = false
+
+		// provide simple predicate that returns false on the second repeat
+		let res = scheduler.start(0, subscribed: 0, disposed: 1000) { () -> Observable<Int> in
+			return self.sampleValues.asObservable().repeatWithBehavior(.Immediate(maxCount: 3), scheduler: self.scheduler) {_ in
+                isRepeat = !isRepeat
+				return isRepeat
+			}
+		}
+		
+		XCTAssertEqual(res.events, immediateCorrectValues)
+	}
+
+	func testImmediateNotRepeatWithPredicate() {
+		let correctValues = [
+			next(210, 1),
+			next(220, 2),
+            completed(300)]
+		
+		// provide simple predicate that always return false (so, sequence will not repeated)
+		let res = scheduler.start(0, subscribed: 0, disposed: 1000) { () -> Observable<Int> in
+			return self.sampleValues.asObservable().repeatWithBehavior(.Immediate(maxCount: 3), scheduler: self.scheduler) { _ in
+				return false
+			}
+		}
+		
+		XCTAssertEqual(res.events, correctValues)
+	}
+
+    func testImmediateNotRepeatWithPredicateWithError() {
+        let res = scheduler.start(0, subscribed: 0, disposed: 1000) { () -> Observable<Int> in
+            return self.sampleValuesWithError.asObservable().repeatWithBehavior(.Immediate(maxCount: 3), scheduler: self.scheduler) { _ in
+                return false
+            }
+        }
+        XCTAssertEqual(res.events, erroredCorrectValues)
+    }
+
+    //MARK: delayed repeats
+
+	func testDelayedRepeatWithoutPredicate() {
+		let correctValues = [
+			next(210, 1),
+			next(220, 2),
+			next(511, 1),
+			next(521, 2),
+			next(812, 1),
+			next(822, 2),
+			completed(902)]
+		
+		let res = scheduler.start(0, subscribed: 0, disposed: 1000) { () -> Observable<Int> in
+			return self.sampleValues.asObservable().repeatWithBehavior(.Delayed(maxCount: 3, time: 1.0), scheduler: self.scheduler)
+		}
+		
+		XCTAssertEqual(res.events, correctValues)
+	}
+
+	func testDelayedRepeatWithPredicate() {
+        let correctValues = [
+            next(210, 1),
+            next(220, 2),
+            next(511, 1),
+            next(521, 2),
+            next(812, 1),
+            next(822, 2),
+            completed(902)]
+
+		let res = scheduler.start(0, subscribed: 0, disposed: 1000) { () -> Observable<Int> in
+			return self.sampleValues.asObservable().repeatWithBehavior(.Delayed(maxCount: 3, time: 1.0), scheduler: self.scheduler) { _ in
+				return true
+			}
+		}
+		
+		XCTAssertEqual(res.events, correctValues)
+	}
+
+    func testDelayedNotRepeatWithPredicate() {
+		let correctValues = [
+			next(210, 1),
+			next(220, 2),
+			completed(300)]
+		
+		let res = scheduler.start(0, subscribed: 0, disposed: 1000) { () -> Observable<Int> in
+			return self.sampleValues.asObservable().repeatWithBehavior(.Delayed(maxCount: 3, time: 5.0), scheduler: self.scheduler) { _ in
+				return false
+			}
+		}
+		
+		XCTAssertEqual(res.events, correctValues)
+	}
+
+    func testDelayedNotRepeatWithPredicateWithError() {
+        let res = scheduler.start(0, subscribed: 0, disposed: 1000) { () -> Observable<Int> in
+            return self.sampleValuesWithError.asObservable().repeatWithBehavior(.Delayed(maxCount: 3, time: 5.0), scheduler: self.scheduler) { _ in
+                return false
+            }
+        }
+        XCTAssertEqual(res.events, erroredCorrectValues)
+    }
+
+    //MARK: exponential delay repeats
+
+	func testExponentialRepeatWithoutPredicate() {
+		let res = scheduler.start(0, subscribed: 0, disposed: 1000) { () -> Observable<Int> in
+			return self.sampleValues.asObservable().repeatWithBehavior(.ExponentialDelayed(maxCount: 3, initial: 2.0, multiplier: 2.0), scheduler: self.scheduler)
+		}
+		XCTAssertEqual(res.events, exponentialCorrectValues)
+	}
+
+	func testExponentialRepeatWithPredicate() {
+		let res = scheduler.start(0, subscribed: 0, disposed: 1000) { () -> Observable<Int> in
+			return self.sampleValues.asObservable().repeatWithBehavior(.ExponentialDelayed(maxCount: 3, initial: 2.0, multiplier: 2.0), scheduler: self.scheduler) { _ in
+				return true
+			}
+		}
+		XCTAssertEqual(res.events, exponentialCorrectValues)
+	}
+
+	func testExponentialNotRepeatWithPredicate() {
+        let correctValues = [
+            next(210, 1),
+            next(220, 2),
+            completed(300)]
+
+		let res = scheduler.start(0, subscribed: 0, disposed: 1000) { () -> Observable<Int> in
+			return self.sampleValues.asObservable().repeatWithBehavior(.ExponentialDelayed(maxCount: 3, initial: 2.0, multiplier: 2.0), scheduler: self.scheduler) { _ in
+				return false
+			}
+		}
+		
+		XCTAssertEqual(res.events, correctValues)
+	}
+
+    func testExponentialNotRepeatWithPredicateWithError() {
+        let res = scheduler.start(0, subscribed: 0, disposed: 1000) { () -> Observable<Int> in
+            return self.sampleValuesWithError.asObservable().repeatWithBehavior(.ExponentialDelayed(maxCount: 3, initial: 2.0, multiplier: 2.0), scheduler: self.scheduler) { _ in
+                return false
+            }
+        }
+        XCTAssertEqual(res.events, erroredCorrectValues)
+    }
+
+    //MARK: custom delay repeats
+
+    // custom delay calculator
+    let customCalculator: (UInt) -> Double = { attempt in
+        switch attempt {
+        case 1: return 10.0
+        case 2: return 30.0
+        default: return 0
+        }
+    }
+
+	func testCustomTimerRepeatWithoutPredicate() {
+		let res = scheduler.start(0, subscribed: 0, disposed: 2000) { () -> Observable<Int> in
+			return self.sampleValues.asObservable().repeatWithBehavior(.CustomTimerDelayed(maxCount: 3, delayCalculator: self.customCalculator), scheduler: self.scheduler)
+		}
+		XCTAssertEqual(res.events, customDelayCorrectValues)
+	}
+
+	func testCustomTimerRepeatWithPredicate() {
+        let res = scheduler.start(0, subscribed: 0, disposed: 2000) { () -> Observable<Int> in
+			return self.sampleValues.asObservable().repeatWithBehavior(.CustomTimerDelayed(maxCount: 3, delayCalculator: self.customCalculator), scheduler: self.scheduler) { _ in
+				return true
+			}
+		}
+		XCTAssertEqual(res.events, customDelayCorrectValues)
+	}
+
+    func testCustomTimerRepeatWithPredicateWithError() {
+        let res = scheduler.start(0, subscribed: 0, disposed: 1000) { () -> Observable<Int> in
+            return self.sampleValuesWithError.asObservable().repeatWithBehavior(.CustomTimerDelayed(maxCount: 3, delayCalculator: self.customCalculator), scheduler: self.scheduler) { _ in
+                return false
+            }
+        }
+        XCTAssertEqual(res.events, erroredCorrectValues)
+    }
+
+}

--- a/Source/repeatWithBehavior.swift
+++ b/Source/repeatWithBehavior.swift
@@ -11,9 +11,10 @@ import RxSwift
 public typealias RepeatPredicate = () -> Bool
 
 /*
-Uses RepeatBehavior and RepeatPredicate defined in retryWithBehavior
+ Uses RepeatBehavior defined in retryWithBehavior
 */
 
+/** Dummy error to use with catchError to restart the observable */
 private enum RepeatError: ErrorType {
     case catchable
 }
@@ -21,11 +22,11 @@ private enum RepeatError: ErrorType {
 extension ObservableType {
 
     /**
-	Repeats the source observable sequence using given behavior in case of an error or until it successfully terminated
-	- parameter behavior: Behavior that will be used in case of an error
+	Repeats the source observable sequence using given behavior when it completes
+	- parameter behavior: Behavior that will be used when the observable completes
 	- parameter scheduler: Schedular that will be used for delaying subscription after error
-	- parameter shouldRetry: Custom optional closure for checking error (if returns true, repeat will be performed)
-	- returns: Observable sequence that will be automatically repeat if error occurred
+	- parameter shouldRepeat: Custom optional closure for decided whether the observable should repeat another round
+	- returns: Observable sequence that will be automatically repeat when it completes
 	*/
 	@warn_unused_result(message="http://git.io/rxs.uo")
 	public func repeatWithBehavior(behavior: RepeatBehavior, scheduler : SchedulerType = MainScheduler.instance, shouldRepeat : RepeatPredicate? = nil) -> Observable<E> {
@@ -33,12 +34,12 @@ extension ObservableType {
 	}
 	
 	/**
-	Repeats the source observable sequence using given behavior in case of an error or until it successfully terminated
-	- parameter currentAttempt: Number of current attempt
-	- parameter behavior: Behavior that will be used in case of an error
+	Repeats the source observable sequence using given behavior when it completes
+	- parameter currentRepeat: Number of the current repetition
+	- parameter behavior: Behavior that will be used in case of completion
 	- parameter scheduler: Schedular that will be used for delaying subscription after error
-	- parameter shouldRetry: Custom optional closure for checking error (if returns true, repeat will be performed)
-	- returns: Observable sequence that will be automatically repeat if error occurred
+	- parameter shouldRepeat: Custom optional closure for decided whether the observable should repeat another round
+	- returns: Observable sequence that will be automatically repeat when it completes
 	*/
 	@warn_unused_result(message="http://git.io/rxs.uo")
 	internal func repeatWithBehavior(currentRepeat: UInt, behavior: RepeatBehavior, scheduler : SchedulerType = MainScheduler.instance, shouldRepeat : RepeatPredicate? = nil)

--- a/Source/repeatWithBehavior.swift
+++ b/Source/repeatWithBehavior.swift
@@ -8,12 +8,19 @@
 import Foundation
 import RxSwift
 
+public typealias RepeatPredicate = () -> Bool
+
 /*
 Uses RepeatBehavior and RepeatPredicate defined in retryWithBehavior
 */
 
+private enum RepeatError: ErrorType {
+    case catchable
+}
+
 extension ObservableType {
-	/**
+
+    /**
 	Repeats the source observable sequence using given behavior in case of an error or until it successfully terminated
 	- parameter behavior: Behavior that will be used in case of an error
 	- parameter scheduler: Schedular that will be used for delaying subscription after error
@@ -21,8 +28,8 @@ extension ObservableType {
 	- returns: Observable sequence that will be automatically repeat if error occurred
 	*/
 	@warn_unused_result(message="http://git.io/rxs.uo")
-	public func `repeat`(behavior: RepeatBehavior, scheduler : SchedulerType = MainScheduler.instance, shouldRetry : RepeatPredicate? = nil) -> Observable<E> {
-		return `repeat`(1, behavior: behavior, scheduler: scheduler, shouldRetry: shouldRetry)
+	public func repeatWithBehavior(behavior: RepeatBehavior, scheduler : SchedulerType = MainScheduler.instance, shouldRepeat : RepeatPredicate? = nil) -> Observable<E> {
+		return repeatWithBehavior(1, behavior: behavior, scheduler: scheduler, shouldRepeat: shouldRepeat)
 	}
 	
 	/**
@@ -34,31 +41,37 @@ extension ObservableType {
 	- returns: Observable sequence that will be automatically repeat if error occurred
 	*/
 	@warn_unused_result(message="http://git.io/rxs.uo")
-	internal func `repeat`(currentRepeat: UInt, behavior: RepeatBehavior, scheduler : SchedulerType = MainScheduler.instance, shouldRetry : RepeatPredicate? = nil)
+	internal func repeatWithBehavior(currentRepeat: UInt, behavior: RepeatBehavior, scheduler : SchedulerType = MainScheduler.instance, shouldRepeat : RepeatPredicate? = nil)
 		-> Observable<E> {
 			guard currentRepeat > 0 else { return Observable.empty() }
 			
 			// calculate conditions for bahavior
 			let conditions = behavior.calculateConditions(currentRepeat)
-			
-			return catchError { error -> Observable<E> in
-				// return error if exceeds maximum amount of retries
-				guard conditions.maxCount > currentRepeat else { return Observable.error(error) }
-				
-				if let shouldRetry = shouldRetry where !shouldRetry(error) {
-					// also return error if predicate says so
-					return Observable.error(error)
-				}
 
-				guard conditions.delay > 0.0 else {
-					// if there is no delay, simply retry
-					return self.retry(currentRepeat + 1, behavior: behavior, scheduler: scheduler, shouldRetry: shouldRetry)
-				}
-				
-				// otherwise retry after specified delay
-				return Observable<Void>.just().delaySubscription(conditions.delay, scheduler: scheduler).flatMapLatest {
-					self.retry(currentRepeat + 1, behavior: behavior, scheduler: scheduler, shouldRetry: shouldRetry)
-				}
-			}
+            return concat(Observable.error(RepeatError.catchable))
+                .catchError {error in
+                    //if observable errors, forward the error
+                    guard error is RepeatError else {
+                        return Observable.error(error)
+                    }
+
+                    //repeat
+                    guard conditions.maxCount > currentRepeat else { return Observable.empty() }
+
+                    if let shouldRepeat = shouldRepeat where !shouldRepeat() {
+                        // also return error if predicate says so
+                        return Observable.empty()
+                    }
+
+                    guard conditions.delay > 0.0 else {
+                        // if there is no delay, simply retry
+                        return self.repeatWithBehavior(currentRepeat + 1, behavior: behavior, scheduler: scheduler, shouldRepeat: shouldRepeat)
+                    }
+
+                    // otherwise retry after specified delay
+                    return Observable<Void>.just().delaySubscription(conditions.delay, scheduler: scheduler).flatMapLatest {
+                        self.repeatWithBehavior(currentRepeat + 1, behavior: behavior, scheduler: scheduler, shouldRepeat: shouldRepeat)
+                    }
+                }
 	}
 }

--- a/Source/repeatWithBehavior.swift
+++ b/Source/repeatWithBehavior.swift
@@ -1,0 +1,64 @@
+//
+//  repeatWithBehavior.swift
+//
+//  Created by Marin Todorov
+//  Copyright © 2016 RxSwift Community. All rights reserved.
+//
+
+import Foundation
+import RxSwift
+
+/*
+Uses RepeatBehavior and RepeatPredicate defined in retryWithBehavior
+*/
+
+extension ObservableType {
+	/**
+	Repeats the source observable sequence using given behavior in case of an error or until it successfully terminated
+	- parameter behavior: Behavior that will be used in case of an error
+	- parameter scheduler: Schedular that will be used for delaying subscription after error
+	- parameter shouldRetry: Custom optional closure for checking error (if returns true, repeat will be performed)
+	- returns: Observable sequence that will be automatically repeat if error occurred
+	*/
+	@warn_unused_result(message="http://git.io/rxs.uo")
+	public func `repeat`(behavior: RepeatBehavior, scheduler : SchedulerType = MainScheduler.instance, shouldRetry : RepeatPredicate? = nil) -> Observable<E> {
+		return `repeat`(1, behavior: behavior, scheduler: scheduler, shouldRetry: shouldRetry)
+	}
+	
+	/**
+	Repeats the source observable sequence using given behavior in case of an error or until it successfully terminated
+	- parameter currentAttempt: Number of current attempt
+	- parameter behavior: Behavior that will be used in case of an error
+	- parameter scheduler: Schedular that will be used for delaying subscription after error
+	- parameter shouldRetry: Custom optional closure for checking error (if returns true, repeat will be performed)
+	- returns: Observable sequence that will be automatically repeat if error occurred
+	*/
+	@warn_unused_result(message="http://git.io/rxs.uo")
+	internal func `repeat`(currentRepeat: UInt, behavior: RepeatBehavior, scheduler : SchedulerType = MainScheduler.instance, shouldRetry : RepeatPredicate? = nil)
+		-> Observable<E> {
+			guard currentRepeat > 0 else { return Observable.empty() }
+			
+			// calculate conditions for bahavior
+			let conditions = behavior.calculateConditions(currentRepeat)
+			
+			return catchError { error -> Observable<E> in
+				// return error if exceeds maximum amount of retries
+				guard conditions.maxCount > currentRepeat else { return Observable.error(error) }
+				
+				if let shouldRetry = shouldRetry where !shouldRetry(error) {
+					// also return error if predicate says so
+					return Observable.error(error)
+				}
+
+				guard conditions.delay > 0.0 else {
+					// if there is no delay, simply retry
+					return self.retry(currentRepeat + 1, behavior: behavior, scheduler: scheduler, shouldRetry: shouldRetry)
+				}
+				
+				// otherwise retry after specified delay
+				return Observable<Void>.just().delaySubscription(conditions.delay, scheduler: scheduler).flatMapLatest {
+					self.retry(currentRepeat + 1, behavior: behavior, scheduler: scheduler, shouldRetry: shouldRetry)
+				}
+			}
+	}
+}

--- a/Source/retryWithBehavior.swift
+++ b/Source/retryWithBehavior.swift
@@ -18,35 +18,35 @@ Delay will be incremented by multiplier after each iteration (multiplier = 0.5 m
 - CustomTimerDelayed: Will be repeated specified number of times. Delay will be calculated by custom closure
 */
 public enum RepeatBehavior {
-	case Immediate (maxAttemptCount: UInt)
-	case Delayed (maxAttemptCount: UInt, time: Double)
-	case ExponentialDelayed (maxAttemptCount: UInt, initial: Double, multiplier: Double)
-	case CustomTimerDelayed (maxAttemptCount: UInt, delayCalculator:(UInt -> Double))
+	case Immediate (maxCount: UInt)
+	case Delayed (maxCount: UInt, time: Double)
+	case ExponentialDelayed (maxCount: UInt, initial: Double, multiplier: Double)
+	case CustomTimerDelayed (maxCount: UInt, delayCalculator: (UInt) -> Double)
 }
 
 public typealias RepeatPredicate = (ErrorType) -> Bool
 
 extension RepeatBehavior {
 	/**
-	Extracts maxAttemptCount and calculates delay for current RepeatBehavior
+	Extracts maxCount and calculates delay for current RepeatBehavior
 	- parameter currentAttempt: Number of current attempt
-	- returns: Tuple with maxAttemptCount and calculated delay for provided attempt
+	- returns: Tuple with maxCount and calculated delay for provided attempt
 	*/
-	func calculateConditions(currentAttempt: UInt) -> (maxAttemptCount: UInt, delay: Double) {
+	func calculateConditions(currentRepetition: UInt) -> (maxCount: UInt, delay: Double) {
 		switch self {
 		case .Immediate(let max):
 			// if Immediate, return 0.0 as delay
-			return (maxAttemptCount: max, delay: 0.0)
+			return (maxCount: max, delay: 0.0)
 		case .Delayed(let max, let time):
 			// return specified delay
-			return (maxAttemptCount: max, delay: time)
+			return (maxCount: max, delay: time)
 		case .ExponentialDelayed(let max, let initial, let multiplier):
 			// if it's first attempt, simply use initial delay, otherwise calculate delay
-			let delay = currentAttempt == 1 ? initial : initial * pow(1 + multiplier, Double(currentAttempt - 1))
-			return (maxAttemptCount: max, delay: delay)
+			let delay = currentRepetition == 1 ? initial : initial * pow(1 + multiplier, Double(currentRepetition - 1))
+			return (maxCount: max, delay: delay)
 		case .CustomTimerDelayed(let max, let delayCalculator):
 			// calculate delay using provided calculator
-			return (maxAttemptCount: max, delay: delayCalculator(currentAttempt))
+			return (maxCount: max, delay: delayCalculator(currentRepetition))
 		}
 	}
 }
@@ -82,7 +82,7 @@ extension ObservableType {
 			
 			return catchError { error -> Observable<E> in
 				// return error if exceeds maximum amount of retries
-				guard conditions.maxAttemptCount > currentAttempt else { return Observable.error(error) }
+				guard conditions.maxCount > currentAttempt else { return Observable.error(error) }
 				
 				if let shouldRetry = shouldRetry where !shouldRetry(error) {
 					// also return error if predicate says so

--- a/Source/retryWithBehavior.swift
+++ b/Source/retryWithBehavior.swift
@@ -24,7 +24,7 @@ public enum RepeatBehavior {
 	case CustomTimerDelayed (maxCount: UInt, delayCalculator: (UInt) -> Double)
 }
 
-public typealias RepeatPredicate = (ErrorType) -> Bool
+public typealias RetryPredicate = (ErrorType) -> Bool
 
 extension RepeatBehavior {
 	/**
@@ -60,7 +60,7 @@ extension ObservableType {
 	- returns: Observable sequence that will be automatically repeat if error occurred
 	*/
 	@warn_unused_result(message="http://git.io/rxs.uo")
-	public func retry(behavior: RepeatBehavior, scheduler : SchedulerType = MainScheduler.instance, shouldRetry : RepeatPredicate? = nil) -> Observable<E> {
+	public func retry(behavior: RepeatBehavior, scheduler: SchedulerType = MainScheduler.instance, shouldRetry: RetryPredicate? = nil) -> Observable<E> {
 		return retry(1, behavior: behavior, scheduler: scheduler, shouldRetry: shouldRetry)
 	}
 	
@@ -73,7 +73,7 @@ extension ObservableType {
 	- returns: Observable sequence that will be automatically repeat if error occurred
 	*/
 	@warn_unused_result(message="http://git.io/rxs.uo")
-	internal func retry(currentAttempt: UInt, behavior: RepeatBehavior, scheduler : SchedulerType = MainScheduler.instance, shouldRetry : RepeatPredicate? = nil)
+	internal func retry(currentAttempt: UInt, behavior: RepeatBehavior, scheduler: SchedulerType = MainScheduler.instance, shouldRetry: RetryPredicate? = nil)
 		-> Observable<E> {
 			guard currentAttempt > 0 else { return Observable.empty() }
 			


### PR DESCRIPTION
@fpillet - coded this one in the way you suggested - pr includes playground page + tests (mostly copied from the retry op)

since `repeat` is a reserved word in swift I implemented it as `repeatWithBehavior`, what do you think about that? Not coherent with the `retry` operator but it doesn't require backticks to use ... 