### PR TITLE
Add materialize/dematerialize operators

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 1. Make sure you have [Carthage](https://github.com/Carthage/Carthage) installed. We use it to pull the RxSwiftExt dependency for development.
 2. Check out this repository.
-3. Do a `carthage update --platform ios`
+3. Do a `carthage update --platform ios --no-use-binaries`
 4. Open `RxSwiftExt.xcworkspace` and start hacking!
 
 ## About contributions

--- a/Playground/RxSwiftExtPlayground.playground/Pages/materialize.xcplaygroundpage/Contents.swift
+++ b/Playground/RxSwiftExtPlayground.playground/Pages/materialize.xcplaygroundpage/Contents.swift
@@ -23,51 +23,41 @@ import RxSwiftExt
  - seealso: [materialize operator on reactivex.io](http://reactivex.io/documentation/operators/materialize-dematerialize.html)
  */
 example("materialize a sequence") {
-
     let numbers = [1, 2, 3]
-
     print("materialize() transformed \(numbers) to sequence of Events: ")
-
     let materialized = Observable.from(numbers).materialize()
-
-    materialized.subscribe(onNext: { result in
+    materialized.subscribe{ result in
         print(result)
-    })
-
-    print()
-    print("...and dematerialize() transformed it back: ")
-
-    materialized.dematerialize().subscribe(onNext: { result in
+    }
+    print("\n...and dematerialize() transformed it back: ")
+    materialized.dematerialize().subscribe { result in
         print(result)
-    })
+    }
 }
 
 example("materialize errors") {
     enum MyErrors: Error {
         case AnError(input: Int)
     }
-
     // Simulate a network request with a 50% chance of failure
     func myRequest(input: Int) -> Observable<Int> {
-        if arc4random() % 2 == 0 { return Observable.just(input) }
+        if arc4random() % 2 == 0 {
+            return Observable.just(input)
+        }
         return Observable.error(MyErrors.AnError(input: input))
     }
-
     let materialized = Observable<Int>.range(start: 0, count: 10)
         .flatMap { input -> Observable<Event<Int>> in
             return myRequest(input: input).materialize()
-        }.publish()
-
-    // Be careful that for cold observables, each subscription to the materialized sequence results in the underlying sequences being regenerated. For hot observables that is not an issue.
-
+        }
+        .publish()
+     // For cold observables, each subscription to the materialized sequence results in the underlying sequences being regenerated. For hot observables that is not an issue. We use `publish` to turn this cold observable into a hot one.
     materialized.elements().subscribe(onNext: { result in
         print("Successful request: \(result)")
     })
-
     materialized.errors().subscribe(onNext: { result in
         print("Unsuccessful request: \(result)")
     })
-
     materialized.connect()
 }
 

--- a/Playground/RxSwiftExtPlayground.playground/Pages/materialize.xcplaygroundpage/Contents.swift
+++ b/Playground/RxSwiftExtPlayground.playground/Pages/materialize.xcplaygroundpage/Contents.swift
@@ -1,0 +1,74 @@
+/*:
+ > # IMPORTANT: To use `RxSwiftExtPlayground.playground`, please:
+
+1. Make sure you have [Carthage](https://github.com/Carthage/Carthage) installed
+1. Fetch Carthage dependencies from shell: `carthage bootstrap --platform ios`
+1. Build scheme `RxSwiftExt (playground)` scheme for a simulator target
+1. Choose `View > Show Debug Area`
+ */
+
+//: [Previous](@previous)
+
+import Foundation
+import RxSwift
+import RxSwiftExt
+
+/*:
+ ## materialize()
+
+ The `materialize` operator takes a sequence of elements and returns a sequence of Event<T>, with Error and Completed events explicitly represented. The returned sequence never errors out, though it might complete.
+
+ The `dematerialize` operator performs the inverse operation, taking a sequence of Event<T> and returning a sequence of T. If the underlying operator has elements of type Event.error or Event.completed, the dematerialized sequence errors or completes, respectively.
+ 
+ - seealso: [materialize operator on reactivex.io](http://reactivex.io/documentation/operators/materialize-dematerialize.html)
+ */
+example("materialize a sequence") {
+
+    let numbers = [1, 2, 3]
+
+    print("materialize() transformed \(numbers) to sequence of Events: ")
+
+    let materialized = Observable.from(numbers).materialize()
+
+    materialized.subscribe(onNext: { result in
+        print(result)
+    })
+
+    print()
+    print("...and dematerialize() transformed it back: ")
+
+    materialized.dematerialize().subscribe(onNext: { result in
+        print(result)
+    })
+}
+
+example("materialize errors") {
+    enum MyErrors: Error {
+        case AnError(input: Int)
+    }
+
+    // Simulate a network request with a 50% chance of failure
+    func myRequest(input: Int) -> Observable<Int> {
+        if arc4random() % 2 == 0 { return Observable.just(input) }
+        return Observable.error(MyErrors.AnError(input: input))
+    }
+
+    let materialized = Observable<Int>.range(start: 0, count: 10)
+        .flatMap { input -> Observable<Event<Int>> in
+            return myRequest(input: input).materialize()
+        }.publish()
+
+    // Be careful that for cold observables, each subscription to the materialized sequence results in the underlying sequences being regenerated. For hot observables that is not an issue.
+
+    materialized.elements().subscribe(onNext: { result in
+        print("Successful request: \(result)")
+    })
+
+    materialized.errors().subscribe(onNext: { result in
+        print("Unsuccessful request: \(result)")
+    })
+
+    materialized.connect()
+}
+
+//: [Next](@next)

--- a/Playground/RxSwiftExtPlayground.playground/contents.xcplayground
+++ b/Playground/RxSwiftExtPlayground.playground/contents.xcplayground
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='6.0' target-platform='ios' display-mode='raw' executeOnSourceChanges='false'>
+<playground version='6.0' target-platform='ios' display-mode='rendered' executeOnSourceChanges='false'>
     <pages>
         <page name='Index'/>
         <page name='cascade'/>
@@ -7,6 +7,7 @@
         <page name='distinct'/>
         <page name='ignore'/>
         <page name='mapTo'/>
+        <page name='materialize'/>
         <page name='not'/>
         <page name='once'/>
         <page name='pausable'/>

--- a/Readme.md
+++ b/Readme.md
@@ -293,8 +293,11 @@ More examples are available in the project's Playground.
 
 #### materialize/dematerialize
 
-Materialize converts an observable into a sequence of Events. Dematerialize
-performs the inverse operation.
+Materialize converts an observable into a sequence of Events for both items
+emitted and notifications sent. Dematerialize performs the inverse
+operation. See the documentation for
+[materialize/dematerialize](http://reactivex.io/documentation/operators/materialize-dematerialize.html)
+on ReactiveX.io.
 
 ```swift
     let numbers = [1, 2, 3]

--- a/Readme.md
+++ b/Readme.md
@@ -50,6 +50,7 @@ RxSwiftExt is all about adding operators to [RxSwift](https://github.com/Reactiv
 * [repeatWithBehavior](#repeatwithbehavior)
 * [catchErrorJustComplete](#catcherrorjustcomplete)
 * [pausable](#pausable)
+* [materialize/dematerialize](#materialize/dematerialize)
 
 #### unwrap
 
@@ -289,6 +290,39 @@ Next(3)
 ```
 
 More examples are available in the project's Playground.
+
+#### materialize/dematerialize
+
+Materialize converts an observable into a sequence of Events. Dematerialize
+performs the inverse operation.
+
+```swift
+    let numbers = [1, 2, 3]
+    print("materialize() transformed \(numbers) to sequence of Events: ")
+    let materialized = Observable.from(numbers).materialize()
+    materialized.subscribe{ result in
+        print(result)
+    }
+    print("\n...and dematerialize() transformed it back: ")
+    materialized.dematerialize().subscribe { result in
+        print(result)
+    }
+```
+
+```
+materialize() transformed [1, 2, 3] to sequence of Events: 
+next(next(1))
+next(next(2))
+next(next(3))
+next(completed)
+completed
+
+...and dematerialize() transformed it back: 
+next(1)
+next(2)
+next(3)
+completed
+```
 
 ## License
 

--- a/Readme.md
+++ b/Readme.md
@@ -50,7 +50,7 @@ RxSwiftExt is all about adding operators to [RxSwift](https://github.com/Reactiv
 * [repeatWithBehavior](#repeatwithbehavior)
 * [catchErrorJustComplete](#catcherrorjustcomplete)
 * [pausable](#pausable)
-* [materialize/dematerialize](#materialize/dematerialize)
+* [materialize/dematerialize](#materializedematerialize)
 
 #### unwrap
 

--- a/RxSwiftExt.xcodeproj/project.pbxproj
+++ b/RxSwiftExt.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		188C6DA31C47B4240092101A /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 188C6DA21C47B4240092101A /* RxSwift.framework */; };
+		1A5542941E1EDD4E001F3121 /* materialize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A5542931E1EDD4E001F3121 /* materialize.swift */; };
+		1A5542961E1EE3DE001F3121 /* materializeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A5542951E1EE3DE001F3121 /* materializeTests.swift */; };
 		3D638DEC1DC2B2D50089A590 /* RxSwiftExt.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 188C6D911C47B2B20092101A /* RxSwiftExt.framework */; };
 		3D638E0F1DC2B33E0089A590 /* cascadeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D638DF31DC2B3060089A590 /* cascadeTests.swift */; };
 		3D638E101DC2B33F0089A590 /* catchErrorJustCompleteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D638DF41DC2B3060089A590 /* catchErrorJustCompleteTests.swift */; };
@@ -55,6 +57,8 @@
 /* Begin PBXFileReference section */
 		188C6D911C47B2B20092101A /* RxSwiftExt.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxSwiftExt.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		188C6DA21C47B4240092101A /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = Carthage/Build/iOS/RxSwift.framework; sourceTree = SOURCE_ROOT; };
+		1A5542931E1EDD4E001F3121 /* materialize.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = materialize.swift; path = Source/materialize.swift; sourceTree = SOURCE_ROOT; };
+		1A5542951E1EE3DE001F3121 /* materializeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = materializeTests.swift; path = Tests/materializeTests.swift; sourceTree = "<group>"; };
 		3D638DE71DC2B2D40089A590 /* RxSwiftExtTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RxSwiftExtTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3D638DF31DC2B3060089A590 /* cascadeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = cascadeTests.swift; path = Tests/cascadeTests.swift; sourceTree = "<group>"; };
 		3D638DF41DC2B3060089A590 /* catchErrorJustCompleteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = catchErrorJustCompleteTests.swift; path = Tests/catchErrorJustCompleteTests.swift; sourceTree = "<group>"; };
@@ -123,6 +127,7 @@
 				9DAB77841D67639C007E85BC /* ignoreWhen.swift */,
 				9DAB77851D67639C007E85BC /* Info.plist */,
 				9DAB77861D67639C007E85BC /* mapTo.swift */,
+				1A5542931E1EDD4E001F3121 /* materialize.swift */,
 				9DAB77871D67639C007E85BC /* not.swift */,
 				9DAB77881D67639C007E85BC /* ObservableType+Weak.swift */,
 				9DAB77891D67639C007E85BC /* once.swift */,
@@ -165,6 +170,7 @@
 				3D638DF71DC2B3060089A590 /* IgnoreTests.swift */,
 				3D638DF81DC2B3060089A590 /* ignoreWhenTests.swift */,
 				3D638DF91DC2B3060089A590 /* mapToTests.swift */,
+				1A5542951E1EE3DE001F3121 /* materializeTests.swift */,
 				3D638DFA1DC2B3060089A590 /* notTests.swift */,
 				3D638DFB1DC2B3060089A590 /* OnceTests.swift */,
 				3DB034FC1DC3A724002C6A26 /* pausableTests.swift */,
@@ -328,6 +334,7 @@
 				9DAB77971D67639C007E85BC /* retryWithBehavior.swift in Sources */,
 				9DAB778D1D67639C007E85BC /* catchErrorJustComplete.swift in Sources */,
 				3DB035001DC3A787002C6A26 /* pausable.swift in Sources */,
+				1A5542941E1EDD4E001F3121 /* materialize.swift in Sources */,
 				9DAB778E1D67639C007E85BC /* distinct.swift in Sources */,
 				9DAB77981D67639C007E85BC /* unwrap.swift in Sources */,
 				9DAB77931D67639C007E85BC /* mapTo.swift in Sources */,
@@ -349,6 +356,7 @@
 				3D638E121DC2B33F0089A590 /* ignoreErrorsTests.swift in Sources */,
 				3D638E191DC2B33F0089A590 /* retryWithBehaviorTests.swift in Sources */,
 				3D638E1C1DC2B33F0089A590 /* WeakTests.swift in Sources */,
+				1A5542961E1EE3DE001F3121 /* materializeTests.swift in Sources */,
 				3D638E1A1DC2B33F0089A590 /* UnwrapTests.swift in Sources */,
 				3D638E161DC2B33F0089A590 /* notTests.swift in Sources */,
 				3D638E101DC2B33F0089A590 /* catchErrorJustCompleteTests.swift in Sources */,

--- a/Source/materialize.swift
+++ b/Source/materialize.swift
@@ -1,0 +1,77 @@
+//
+//  materialize.swift
+//  RxSwiftExt
+//
+//  Created by Andy Chou on 1/5/17.
+//  Copyright © 2017 RxSwiftCommunity. All rights reserved.
+//
+
+import Foundation
+import RxSwift
+
+extension ObservableType {
+    /**
+     Convert any Observable into an Observable of its events.
+
+     - seealso: [materialize operator on reactivex.io](http://reactivex.io/documentation/operators/materialize-dematerialize.html)
+
+     - returns: An observable sequence that wraps events in an Event<E>. The returned Observable never errors, but it does complete after observing all of the events of the underlying Observable.
+     */
+    public func materialize() -> Observable<Event<E>> {
+        return Observable.create { observer in
+            return self.subscribe { event in
+                observer.onNext(event)
+                if event.isStopEvent {
+                    observer.onCompleted()
+                }
+            }
+        }
+    }
+}
+
+/**
+ A type that expresses convertibility into an RxSwift Event<E>.
+ This is used mainly for the implementation of the dematerialize operator.
+ */
+public protocol EventConvertibleType {
+    associatedtype E
+    func asEvent() -> Event<E>
+}
+
+extension Event : EventConvertibleType {
+    public typealias E = Element
+    public func asEvent() -> Event<E> { return self }
+}
+
+extension ObservableType where E: EventConvertibleType {
+    /**
+     Convert an Observable<Event<E>> into an Observable<E> of the Event elements.
+
+     - seealso: [materialize operator on reactivex.io](http://reactivex.io/documentation/operators/materialize-dematerialize.html)
+
+     - returns: An observable sequence that unwraps the Events of the underlying observable.
+     */
+    public func dematerialize() -> Observable<E.E> {
+        return Observable.create { observer in
+            return self.subscribe(onNext: { event in
+                switch event.asEvent() {
+                case .next(let element): observer.onNext(element)
+                case .error(let error): observer.onError(error)
+                case .completed: observer.onCompleted()
+                }
+            })
+        }
+    }
+
+    /// Return only the error events of an Observable<Event<E>>
+    public func errors() -> Observable<Error> {
+        return self.filter { $0.asEvent().error != nil }
+            .map { $0.asEvent().error! }
+    }
+
+    /// Return only the onNext element events of an Observable<Event<E>>
+    public func elements() -> Observable<E.E> {
+        return self.filter { $0.asEvent().element != nil }
+            .map { $0.asEvent().element! }
+    }
+}

--- a/Tests/materializeTests.swift
+++ b/Tests/materializeTests.swift
@@ -1,0 +1,139 @@
+//
+//  MaterializeTests.swift
+//  RxSwiftExt
+//
+//  Created by Andy Chou on 1/5/17.
+//  Copyright © 2017 RxSwiftCommunity. All rights reserved.
+//
+
+import XCTest
+
+import RxSwift
+import RxSwiftExt
+import RxTest
+
+// This is a hack needed to make XCTAssertEqual work for Observables of Recorded<Event<Event<T>>
+extension Event: Equatable { }
+
+public func ==<T>(a: Event<T>, b: Event<T>) -> Bool {
+    switch (a, b) {
+    case let (.next(a), .next(b)):
+        // Is it ugly? Yes. Does it work? Yes.
+        let ae = a as! NSObject
+        let be = b as! NSObject
+        return ae == be
+    case let (.error(err1), .error(err2)):
+        let e1 = err1 as NSError,
+        e2 = err2 as NSError
+        return e1 == e2
+    case (.completed, .completed): return true
+    default: return false
+    }
+}
+
+enum MaterializeError: Error {
+    case anError
+}
+
+class MaterializeTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    func testMaterialize() {
+        let values = [0, 42, -7, 100, 1000, 1]
+
+        let scheduler = TestScheduler(initialClock: 0)
+        let observer = scheduler.createObserver(Event<Int>.self)
+
+        _ = Observable.from(values)
+            .materialize()
+            .subscribe(observer)
+
+        scheduler.start()
+
+        let correct = [
+            next(0, Event.next(0)),
+            next(0, Event.next(42)),
+            next(0, Event.next(-7)),
+            next(0, Event.next(100)),
+            next(0, Event.next(1000)),
+            next(0, Event.next(1)),
+            next(0, Event.completed),
+            completed(0)
+        ]
+
+        XCTAssertEqual(observer.events, correct)
+    }
+
+    func testDematerialize() {
+        let values = [0, 42, -7, 100, 1000, 1]
+
+        let scheduler = TestScheduler(initialClock: 0)
+        let observer = scheduler.createObserver(Int.self)
+
+        _ = Observable.from(values)
+            .materialize()
+            .dematerialize()
+            .subscribe(observer)
+
+        scheduler.start()
+
+        let correct = [
+            next(0, 0),
+            next(0, 42),
+            next(0, -7),
+            next(0, 100),
+            next(0, 1000),
+            next(0, 1),
+            completed(0)
+        ]
+
+        XCTAssertEqual(observer.events, correct)
+    }
+
+    func testMaterializeError() {
+        let scheduler = TestScheduler(initialClock: 0)
+        let observer = scheduler.createObserver(Event<Int>.self)
+
+        _ = Observable.error(MaterializeError.anError)
+            .startWith(42)
+            .materialize()
+            .subscribe(observer)
+
+        scheduler.start()
+
+        let correct = [
+            next(0, Event.next(42)),
+            next(0, Event.error(MaterializeError.anError)),
+            completed(0)
+        ]
+
+        XCTAssertEqual(observer.events, correct)
+    }
+
+    func testDematerializeError() {
+        let scheduler = TestScheduler(initialClock: 0)
+        let observer = scheduler.createObserver(Int.self)
+
+        _ = Observable.error(MaterializeError.anError)
+            .startWith(42)
+            .materialize()
+            .dematerialize()
+            .subscribe(observer)
+
+        scheduler.start()
+
+        let correct = [
+            next(0, 42),
+            error(0, MaterializeError.anError)
+        ]
+
+        XCTAssertEqual(observer.events, correct)
+    }
+}


### PR DESCRIPTION
Includes the operators, tests, playground page, and Readme doc.
I noticed that the instructions for Carthage don't have --no-use-binaries, so I added that to the Contributing doc. But I didn't make the change to the playground files. Might want to consider that as well.
