### PR TITLE
Loosen RxSwift minimum version dependency

### DIFF
--- a/RxSwiftExt.podspec
+++ b/RxSwiftExt.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/RxSwiftCommunity/RxSwiftExt.git", :tag => s.version }
   s.source_files  = "Source/*.swift"
   s.frameworks  = "Foundation"
-  s.dependency "RxSwift", '~> 3.0.0'
+  s.dependency "RxSwift", '~> 3.0'
 end


### PR DESCRIPTION
Loosen RxSwift minimum version dependency to support RxSwift 3.1.0 along side 3.0.x

Solves https://github.com/RxSwiftCommunity/RxSwiftExt/issues/66