### PR TITLE
Rolled back `map(to:)` to `mapTo(_)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+3.1.0
+-----
+- added `and()` operators
+- added support for compiling in an iOS App Extension
+
 3.0.0
 -----
 - added support for Swift 4, RxSwift 4.0

--- a/Playground/RxSwiftExtPlayground.playground/Pages/Index.xcplaygroundpage/Contents.swift
+++ b/Playground/RxSwiftExtPlayground.playground/Pages/Index.xcplaygroundpage/Contents.swift
@@ -25,7 +25,7 @@
  - [unwrap()](unwrap) operator, takes a sequence of optional elements and returns a sequence of non-optional elements, filtering out any `nil` values
  - [ignore(Any...)](ignore) operator, filters out any of the elements passed in parameters
  - [Observable.once(Element)](once) contructor, creates a sequence that delivers an element *once* to the first subscriber then completes. The same sequence will complete immediately without delivering any element to all further subscribers.
- - [map(to: Any)](map) operator, takes a sequence of elements and returns a sequence of the same constant provided as a parameter
+ - [mapTo(Any)](mapTo) operator, takes a sequence of elements and returns a sequence of the same constant provided as a parameter
  - [not()](not) operator, applies a the boolean not (!) to a `Bool`
  - [and()](and) operator, combines Bool values from one or more sequences and emits a single `Bool` value.
  - [Observable.cascade([Observable])](cascade) contructor, takes a ordinary sequence (i.e. Array) of observables and cascades through them

--- a/Playground/RxSwiftExtPlayground.playground/Pages/mapTo.xcplaygroundpage/Contents.swift
+++ b/Playground/RxSwiftExtPlayground.playground/Pages/mapTo.xcplaygroundpage/Contents.swift
@@ -21,7 +21,7 @@ example("replace any input with a value") {
     
     let numbers = Array<Int?>([1, 2, 3])
     Observable.from(numbers)
-        .map(to: "candy")
+        .mapTo("candy")
         .toArray()
 		.subscribe(onNext: {result in
             // look types on the right panel ===>

--- a/Playground/RxSwiftExtPlayground.playground/contents.xcplayground
+++ b/Playground/RxSwiftExtPlayground.playground/contents.xcplayground
@@ -15,7 +15,8 @@
         <page name='retryWithBehavior'/>
         <page name='unwrap'/>
         <page name='filterMap'/>
-        <page name='map'/>
+        <page name='mapTo'/>
         <page name='fromAsync'/>
+        <page name='and'/>
     </pages>
 </playground>

--- a/Source/RxSwift/mapTo.swift
+++ b/Source/RxSwift/mapTo.swift
@@ -17,13 +17,8 @@ extension ObservableType {
 	- parameter value: A constant that each element of the input sequence is being replaced with
 	- returns: An observable sequence containing the values `value` provided as a parameter
 	*/
-  
-	@available(*, deprecated, renamed: "map(to:)")
 	public func mapTo<R>(_ value: R) -> Observable<R> {
-		return map {_ in value}
+		return map { _ in value }
 	}
-  
-	public func map<R>(to value: R) -> Observable<R> {
-		return map {_ in value}
-	}
+
 }

--- a/Tests/RxSwift/mapToTests.swift
+++ b/Tests/RxSwift/mapToTests.swift
@@ -24,7 +24,7 @@ class MapToTests: XCTestCase {
         observer = scheduler.createObserver(String.self)
         
 		_ = Observable.from(numbers)
-            .map(to: "candy")
+            .mapTo("candy")
             .subscribe(observer)
         
         scheduler.start()


### PR DESCRIPTION
This is to avoid conflicts with RxSwift's `map` operator, where the
Swift compiler would use RxSwiftExt's  `map(to:)` when `map` is being used
in its trailing closure form.

To eliminate any ambiguity, we chose to stay away from hidden compiler misdirections.

Fixes #117 