### PR TITLE
zip(with:) extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ DerivedData
 Carthage
 !Carthage/**
 
+# AppCode
+.idea
+
 # Cocoapods
 # We recommend against adding the Pods directory to your .gitignore. However
 # you should judge for yourself, the pros and cons are mentioned at:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+- added `zip(with:)` operator
+
 3.1.0
 -----
 - added `pairwise()` and `nwise(_:)` operators

--- a/Playground/RxSwiftExtPlayground.playground/Pages/zipWith.xcplaygroundpage/Contents.swift
+++ b/Playground/RxSwiftExtPlayground.playground/Pages/zipWith.xcplaygroundpage/Contents.swift
@@ -1,0 +1,37 @@
+/*:
+ > # IMPORTANT: To use `RxSwiftExtPlayground.playground`, please:
+
+1. Make sure you have [Carthage](https://github.com/Carthage/Carthage) installed
+1. Fetch Carthage dependencies from shell: `carthage bootstrap --platform ios`
+1. Build scheme `RxSwiftExtPlayground` scheme for a simulator target
+1. Choose `View > Show Debug Area`
+ */
+
+//: [Previous](@previous)
+
+import RxSwift
+import RxSwiftExt
+
+/*:
+ ## zip(with:)
+
+ Merges the specified observable sequences into one observable sequence by using the selector function whenever all
+ of the observable sequences have produced an element at a corresponding index.
+
+ */
+example("zip values") {
+
+    let numbers = Array<Int>([1, 2, 3])
+    let strings = Array<String>(["a", "b", "c"])
+    Observable.from(numbers)
+            .zip(with: Observable.from(strings)) { i, s in
+                s + String(i)
+            }
+            .toArray()
+            .subscribe(onNext: { result in
+                // look types on the right panel ===>
+                print("zip2(with:) merged \(numbers) with \(strings) to \(result)")
+            })
+}
+
+//: [Next](@next)

--- a/Readme.md
+++ b/Readme.md
@@ -68,6 +68,7 @@ RxSwiftExt is all about adding operators to [RxSwift](https://github.com/Reactiv
 * [apply](#apply)
 * [filterMap](#filtermap)
 * [Observable.fromAsync](#fromasync)
+* [Observable.zip(with:)](#zipwith)
 
 Two additional operators are available for `materialize()`'d sequences:
 
@@ -441,6 +442,22 @@ observableService("Foo", 0)
         print(result)
     })
     .disposed(by: disposeBag)
+```
+
+#### zipWith
+
+Convenience operator for writing:
+
+```
+Observable.just(something)
+    .flatMap { Observable.zip(Observable.just($0), Observable.create { ... }) { join($0, $1) }
+```
+
+Like this:
+
+```
+Observable.just(something)
+    .zip(with: Observable.create { ... }) { join($0, $1) }
 ```
 
 ## License

--- a/RxSwiftExt.xcodeproj/project.pbxproj
+++ b/RxSwiftExt.xcodeproj/project.pbxproj
@@ -69,6 +69,12 @@
 		53C79D621E6F5B3900CD9B6A /* NotTests+RxCocoa.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C79D5F1E6F5AAB00CD9B6A /* NotTests+RxCocoa.swift */; };
 		53F336E81E70CBF700D35D38 /* distinct+RxCocoa.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53F336E71E70CBF700D35D38 /* distinct+RxCocoa.swift */; };
 		53F336EA1E70D59000D35D38 /* DistinctTests+RxCocoa.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53F336E91E70D59000D35D38 /* DistinctTests+RxCocoa.swift */; };
+		58C540CAF254B6B381721654 /* zipWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C54402C636BC3C2F36A4ED /* zipWith.swift */; };
+		58C54302EC14B6FF2034BAF6 /* ZipWithTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C54E184069446EDEE748F9 /* ZipWithTest.swift */; };
+		58C5450451345D65DF48F6C5 /* zipWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C54402C636BC3C2F36A4ED /* zipWith.swift */; };
+		58C545FD1AE234C7F290334F /* ZipWithTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C54E184069446EDEE748F9 /* ZipWithTest.swift */; };
+		58C54AED13DBD3CA11D3D772 /* zipWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C54402C636BC3C2F36A4ED /* zipWith.swift */; };
+		58C54B6E1B4C678DE2378145 /* ZipWithTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C54E184069446EDEE748F9 /* ZipWithTest.swift */; };
 		5A1DDEBF1ED58F8600F2E4B1 /* pausableBuffered.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1DDEBE1ED58F8600F2E4B1 /* pausableBuffered.swift */; };
 		5A5FCE411ED5AEC60052A9B5 /* PausableBufferedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1DDEB81ED58D2800F2E4B1 /* PausableBufferedTests.swift */; };
 		62512C661F0EAF670083A89F /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 62512C581F0EAED20083A89F /* RxSwift.framework */; };
@@ -265,6 +271,8 @@
 		53C79D5F1E6F5AAB00CD9B6A /* NotTests+RxCocoa.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NotTests+RxCocoa.swift"; sourceTree = "<group>"; };
 		53F336E71E70CBF700D35D38 /* distinct+RxCocoa.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "distinct+RxCocoa.swift"; path = "Source/RxCocoa/distinct+RxCocoa.swift"; sourceTree = SOURCE_ROOT; };
 		53F336E91E70D59000D35D38 /* DistinctTests+RxCocoa.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DistinctTests+RxCocoa.swift"; sourceTree = "<group>"; };
+		58C54402C636BC3C2F36A4ED /* zipWith.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = zipWith.swift; sourceTree = "<group>"; };
+		58C54E184069446EDEE748F9 /* ZipWithTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZipWithTest.swift; sourceTree = "<group>"; };
 		5A1DDEB81ED58D2800F2E4B1 /* PausableBufferedTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PausableBufferedTests.swift; sourceTree = "<group>"; };
 		5A1DDEBE1ED58F8600F2E4B1 /* pausableBuffered.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = pausableBuffered.swift; path = Source/RxSwift/pausableBuffered.swift; sourceTree = SOURCE_ROOT; };
 		62512C581F0EAED20083A89F /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = Carthage/Build/Mac/RxSwift.framework; sourceTree = "<group>"; };
@@ -437,6 +445,7 @@
 				538607A71E6F334B000361DE /* repeatWithBehavior.swift */,
 				538607A81E6F334B000361DE /* retryWithBehavior.swift */,
 				538607A91E6F334B000361DE /* unwrap.swift */,
+				58C54402C636BC3C2F36A4ED /* zipWith.swift */,
 			);
 			path = RxSwift;
 			sourceTree = "<group>";
@@ -466,6 +475,7 @@
 				538607C91E6F367A000361DE /* UnwrapTests.swift */,
 				538607CA1E6F367A000361DE /* WeakTarget.swift */,
 				538607CB1E6F367A000361DE /* WeakTests.swift */,
+				58C54E184069446EDEE748F9 /* ZipWithTest.swift */,
 			);
 			name = RxSwift;
 			path = Tests/RxSwift;
@@ -866,6 +876,7 @@
 				5386076F1E6F1C0A000361DE /* mapTo+RxCocoa.swift in Sources */,
 				538607B71E6F334B000361DE /* repeatWithBehavior.swift in Sources */,
 				538607AC1E6F334B000361DE /* catchErrorJustComplete.swift in Sources */,
+				58C5450451345D65DF48F6C5 /* zipWith.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -898,6 +909,7 @@
 				538607E61E6F36A9000361DE /* MapToTests.swift in Sources */,
 				5A5FCE411ED5AEC60052A9B5 /* PausableBufferedTests.swift in Sources */,
 				3DBDE5FF1FBBB09900DF47F9 /* AndTests.swift in Sources */,
+				58C545FD1AE234C7F290334F /* ZipWithTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -931,6 +943,7 @@
 				62512C6C1F0EAF950083A89F /* catchErrorJustComplete.swift in Sources */,
 				62512C751F0EAF950083A89F /* once.swift in Sources */,
 				62512C711F0EAF950083A89F /* mapTo.swift in Sources */,
+				58C54AED13DBD3CA11D3D772 /* zipWith.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -963,6 +976,7 @@
 				62512C9D1F0EB1850083A89F /* PausableTests.swift in Sources */,
 				62512C991F0EB1850083A89F /* MapToTests.swift in Sources */,
 				3DBDE6001FBBB09A00DF47F9 /* AndTests.swift in Sources */,
+				58C54302EC14B6FF2034BAF6 /* ZipWithTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -996,6 +1010,7 @@
 				E39C41DD1F18B08A007F2ACD /* catchErrorJustComplete.swift in Sources */,
 				E39C41E61F18B08A007F2ACD /* once.swift in Sources */,
 				E39C41E21F18B08A007F2ACD /* mapTo.swift in Sources */,
+				58C540CAF254B6B381721654 /* zipWith.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1028,6 +1043,7 @@
 				E39C42081F18B13E007F2ACD /* Materialized+elementsTests.swift in Sources */,
 				E39C42071F18B13E007F2ACD /* MapToTests.swift in Sources */,
 				3DBDE6011FBBB09A00DF47F9 /* AndTests.swift in Sources */,
+				58C54B6E1B4C678DE2378145 /* ZipWithTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RxSwiftExt.xcodeproj/xcshareddata/xcschemes/RxSwiftExtTests-iOS.xcscheme
+++ b/RxSwiftExt.xcodeproj/xcshareddata/xcschemes/RxSwiftExtTests-iOS.xcscheme
@@ -5,6 +5,19 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForRunning = "YES"
+            buildForTesting = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3D638DE61DC2B2D40089A590"
+               BuildableName = "RxSwiftExtTests-iOS.xctest"
+               BlueprintName = "RxSwiftExtTests-iOS"
+               ReferencedContainer = "container:RxSwiftExt.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"

--- a/RxSwiftExt.xcodeproj/xcshareddata/xcschemes/RxSwiftExtTests-macOS.xcscheme
+++ b/RxSwiftExt.xcodeproj/xcshareddata/xcschemes/RxSwiftExtTests-macOS.xcscheme
@@ -5,6 +5,19 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForRunning = "YES"
+            buildForTesting = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "62512C831F0EB1280083A89F"
+               BuildableName = "RxSwiftExtTests-macOS.xctest"
+               BlueprintName = "RxSwiftExtTests-macOS"
+               ReferencedContainer = "container:RxSwiftExt.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"

--- a/Source/RxSwift/zipWith.swift
+++ b/Source/RxSwift/zipWith.swift
@@ -1,0 +1,24 @@
+//
+// Created by Arjan Duijzer on 26/12/2017.
+// Copyright (c) 2017 RxSwiftCommunity. All rights reserved.
+//
+
+import RxSwift
+
+extension ObservableConvertibleType {
+
+    /**
+     Merges the specified observable sequences into one observable sequence by using the selector function whenever all of the observable sequences have produced an element at a corresponding index.
+
+     - seealso: [zip operator on reactivex.io](http://reactivex.io/documentation/operators/zip.html)
+
+     - Parameters:
+        - second: A second Observable<T> to zip with `self`
+        - resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
+
+     - Returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
+     */
+    public func zip<O2, ResultType>(with second: O2, resultSelector: @escaping (E, O2.E) throws -> ResultType) -> Observable<ResultType> where O2: ObservableConvertibleType {
+        return Observable.zip(asObservable(), second.asObservable(), resultSelector: resultSelector)
+    }
+}

--- a/Tests/RxSwift/ZipWithTest.swift
+++ b/Tests/RxSwift/ZipWithTest.swift
@@ -1,0 +1,101 @@
+//
+// Created by Arjan Duijzer on 26/12/2017.
+// Copyright (c) 2017 RxSwiftCommunity. All rights reserved.
+//
+
+import XCTest
+import RxSwift
+import RxTest
+
+struct Pair<F: Equatable, S: Equatable> {
+    let first: F
+    let second: S
+}
+
+enum ZipWithTestError: Error {
+    case error
+}
+
+extension Pair: Equatable {
+}
+
+func ==<F, S>(lhs: Pair<F, S>, rhs: Pair<F, S>) -> Bool {
+    return lhs.first == rhs.first && lhs.second == rhs.second
+}
+
+class ZipWithTest: XCTestCase {
+    func testZipWith_SourcesNotEmpty_ZipCompletes() {
+        let scheduler = TestScheduler(initialClock: 0)
+        let source1 = Observable.just(1)
+        let source2 = Observable.just(2)
+
+        let res = scheduler.start {
+            source1.zip(with: source2) {
+                Pair(first: $0, second: $1)
+            }
+        }
+
+        let expected = [next(200, Pair(first: 1, second: 2)), completed(200)]
+        XCTAssertEqual(res.events, expected)
+    }
+
+    func testZipWith_SourceEmpty_ZipCompletesEmpty() {
+        let scheduler = TestScheduler(initialClock: 0)
+        let source1 = Observable.just(1)
+        let source2 = Observable<Int>.empty()
+
+        let res = scheduler.start {
+            source1.zip(with: source2) {
+                Pair(first: $0, second: $1)
+            }
+        }
+
+        let expected: [Recorded<Event<Pair<Int, Int>>>] = [completed(200)]
+        XCTAssertEqual(res.events, expected)
+    }
+
+    func testZipWith_SourceError_ZipCompletesWithError() {
+        let scheduler = TestScheduler(initialClock: 0)
+        let source1 = Observable.just(1)
+        let source2 = Observable<Int>.error(ZipWithTestError.error)
+
+        let res = scheduler.start {
+            source1.zip(with: source2) {
+                Pair(first: $0, second: $1)
+            }
+        }
+
+        let expected: [Recorded<Event<Pair<Int, Int>>>] = [error(200, ZipWithTestError.error)]
+        XCTAssertEqual(res.events, expected)
+    }
+
+    func testMaybeZipWith_SourcesNotEmpty_ZipCompletes() {
+        let scheduler = TestScheduler(initialClock: 0)
+        let source1 = Maybe.just(1)
+        let source2 = Observable.just(2)
+
+        let res = scheduler.start {
+            source1.zip(with: source2) {
+                Pair(first: $0, second: $1)
+            }
+        }
+
+        let expected = [next(200, Pair(first: 1, second: 2)), completed(200)]
+        XCTAssertEqual(res.events, expected)
+    }
+
+    func testSingleZipWith_SourcesNotEmpty_ZipCompletes() {
+        let scheduler = TestScheduler(initialClock: 0)
+        let source1 = Single.just(1)
+        let source2 = Observable.just(2)
+
+        let res = scheduler.start {
+            source1.zip(with: source2) {
+                Pair(first: $0, second: $1)
+            }
+        }
+
+        let expected = [next(200, Pair(first: 1, second: 2)), completed(200)]
+        XCTAssertEqual(res.events, expected)
+    }
+}


### PR DESCRIPTION
This PR adds a convenience operator to `ObservableConvertibleType.zip(with:)` that zips two observable sequences into one sequence on the same Rx Monad.

I thought this operator could be pretty convenient even though zip being a symmetric operator.
Since I've seen and used it quite often in Android/Java projects where the [zipWith](http://reactivex.io/documentation/operators/zip.html#collapseRxJava%C2%A02%E2%80%A4x) operator is available.

I intended it to be a shortcut for:
```
Observable.just(something)
        .flatMap { Observable.zip(Observable.just($0), Observable.create { ... }) { join($0, $1) }
```
to:
```
Observable.just(something)
        .zip(with: Observable.create { ... }) { join($0, $1) }
```

IRL this becomes useful when you have more operators than only Observable.just() on an observable stream. I think it's a more elegant approach and serves readability.
E.g.

```
// Passing down the initial output from source1 through the the stream and use it as input for source2
repo.getEntity(key)
    .flatMap { otherRepo.fetchOther($0.otherKey)
        .zip(with: Observable.just($0)) { ($0, $1) }
    }
    .map { convertModel($0) }
    ...
```

And/or to prevent side-effects:
```
// Combined operation without side-effect
repo.save(entity)
    .flatMap { preferences.save($0.key)
        .zip(with: Observable.just($0)) { ($0, $1) }
    ...
```

To prevent this:
```
// Combined operation with side-effect
repo.save(entity)
    .do(onNext: { preferences.save($0.key)  <- Result ignored by original stream
        .subscribe { ... }  <- Scheduling is not captured by original stream
        .disposed(by: ... )  <-- Is not owned by original stream
    })
    ...
```