### PR TITLE
add a pausable(afterCount:) operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog
 - added `apply` for `Completable` and `Maybe` 
 - added `mapTo` for `Single` and `Maybe`
 - added SPM support
+- added `pausable(afterCount:)` operator
 
 5.0.0
 -----

--- a/Playground/RxSwiftExtPlayground.playground/Pages/pausableAfterCount.xcplaygroundpage/Contents.swift
+++ b/Playground/RxSwiftExtPlayground.playground/Pages/pausableAfterCount.xcplaygroundpage/Contents.swift
@@ -1,0 +1,40 @@
+/*:
+ > # IMPORTANT: To use `RxSwiftExtPlayground.playground`, please:
+
+ 1. Make sure you have [Carthage](https://github.com/Carthage/Carthage) installed
+ 1. Fetch Carthage dependencies from shell: `carthage bootstrap --platform ios`
+ 1. Build scheme `RxSwiftExtPlayground` scheme for a simulator target
+ 1. Choose `View > Show Debug Area`
+ */
+
+//: [Previous](@previous)
+
+import RxSwift
+import RxSwiftExt
+
+/*:
+ ## pausableAfterCount
+
+ The `pausable` operator pauses the elements of the source observable sequence based on the latest element from the second observable sequence.
+ The pause is available only after a certain count of events. Before the number of emitted events reaches that count
+ the Pauser will not be taken care of.
+ - elements from the underlying observable sequence are emitted if and only if the second sequence has most recently emitted `true`.
+ */
+
+example("pausableAfterCount") {
+
+    let observable = Observable<Int>.interval(1, scheduler: MainScheduler.instance)
+
+    let trueAtThreeSeconds = Observable<Int>.timer(3, scheduler: MainScheduler.instance).map { _ in true }
+    let falseAtFiveSeconds = Observable<Int>.timer(5, scheduler: MainScheduler.instance).map { _ in false }
+    let pauser = Observable.of(trueAtThreeSeconds, falseAtFiveSeconds).merge()
+
+    let pausedObservable = observable.pausable(afterCount: 2, withPauser: pauser)
+
+    pausedObservable
+        .subscribe { print($0) }
+
+    playgroundShouldContinueIndefinitely()
+
+}
+//: [Next](@next)

--- a/Playground/RxSwiftExtPlayground.playground/contents.xcplayground
+++ b/Playground/RxSwiftExtPlayground.playground/contents.xcplayground
@@ -13,6 +13,7 @@
         <page name='once'/>
         <page name='pausable'/>
         <page name='pausableBuffered'/>
+        <page name='pausableAfterCount'/>
         <page name='repeatWithBehavior'/>
         <page name='retryWithBehavior'/>
         <page name='unwrap'/>

--- a/Readme.md
+++ b/Readme.md
@@ -68,6 +68,7 @@ These operators are much like the RxSwift & RxCocoa core operators, but provide 
 * [catchErrorJustComplete](#catcherrorjustcomplete)
 * [pausable](#pausable)
 * [pausableBuffered](#pausablebuffered)
+* [pausableAfterCount](#pausableaftercount)
 * [apply](#apply)
 * [filterMap](#filtermap)
 * [Observable.fromAsync](#fromasync)
@@ -427,6 +428,12 @@ More examples are available in the project's Playground.
 #### pausableBuffered
 
 Pauses the elements of the source observable sequence unless the latest element from the second observable sequence is `true`. Elements emitted by the source observable are buffered (with a configurable limit) and "flushed" (re-emitted) when the observable resumes.
+
+Examples are available in the project's Playground.
+
+#### pausableAfterCount
+
+Pauses the elements of the source observable sequence unless the latest element from the second observable sequence is `true`. The pause is available only after a certain count of events. Before the number of emitted events reaches that count the Pauser will not be taken care of.
 
 Examples are available in the project's Playground.
 

--- a/RxSwiftExt.xcodeproj/project.pbxproj
+++ b/RxSwiftExt.xcodeproj/project.pbxproj
@@ -151,6 +151,12 @@
 		782485B7229952FD005CF8CC /* TestErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782485B6229952FD005CF8CC /* TestErrors.swift */; };
 		782485B8229952FD005CF8CC /* TestErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782485B6229952FD005CF8CC /* TestErrors.swift */; };
 		782485B9229952FD005CF8CC /* TestErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782485B6229952FD005CF8CC /* TestErrors.swift */; };
+		783EDF8C2320462A00F5C062 /* pausableAfterCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 783EDF8B2320462A00F5C062 /* pausableAfterCount.swift */; };
+		783EDF8D2320462A00F5C062 /* pausableAfterCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 783EDF8B2320462A00F5C062 /* pausableAfterCount.swift */; };
+		783EDF8E2320462A00F5C062 /* pausableAfterCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 783EDF8B2320462A00F5C062 /* pausableAfterCount.swift */; };
+		783EDF90232048E000F5C062 /* PausableAfterCountTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 783EDF8F232048E000F5C062 /* PausableAfterCountTests.swift */; };
+		783EDF91232048E000F5C062 /* PausableAfterCountTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 783EDF8F232048E000F5C062 /* PausableAfterCountTests.swift */; };
+		783EDF92232048E000F5C062 /* PausableAfterCountTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 783EDF8F232048E000F5C062 /* PausableAfterCountTests.swift */; };
 		789682E720408A7500545396 /* mapAt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CF5F8B2202D6C5F00C1BA97 /* mapAt.swift */; };
 		789682E820408A7700545396 /* mapAt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CF5F8B2202D6C5F00C1BA97 /* mapAt.swift */; };
 		8CF5F8AF202D62AB00C1BA97 /* MapAtTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CF5F8AD202D622000C1BA97 /* MapAtTests.swift */; };
@@ -363,6 +369,8 @@
 		782485922298A702005CF8CC /* mergeWith.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = mergeWith.swift; sourceTree = "<group>"; };
 		782485942298A785005CF8CC /* MergeWithTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MergeWithTests.swift; sourceTree = "<group>"; };
 		782485B6229952FD005CF8CC /* TestErrors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TestErrors.swift; path = Tests/TestErrors.swift; sourceTree = "<group>"; };
+		783EDF8B2320462A00F5C062 /* pausableAfterCount.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = pausableAfterCount.swift; sourceTree = "<group>"; };
+		783EDF8F232048E000F5C062 /* PausableAfterCountTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PausableAfterCountTests.swift; sourceTree = "<group>"; };
 		8CF5F8AD202D622000C1BA97 /* MapAtTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapAtTests.swift; sourceTree = "<group>"; };
 		8CF5F8B2202D6C5F00C1BA97 /* mapAt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = mapAt.swift; sourceTree = "<group>"; };
 		98309EB01EDF159500BD07D9 /* filterMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = filterMap.swift; path = Source/RxSwift/filterMap.swift; sourceTree = SOURCE_ROOT; };
@@ -553,6 +561,7 @@
 				538607A41E6F334B000361DE /* ObservableType+Weak.swift */,
 				538607A51E6F334B000361DE /* once.swift */,
 				538607A61E6F334B000361DE /* pausable.swift */,
+				783EDF8B2320462A00F5C062 /* pausableAfterCount.swift */,
 				5A1DDEBE1ED58F8600F2E4B1 /* pausableBuffered.swift */,
 				538607A71E6F334B000361DE /* repeatWithBehavior.swift */,
 				538607A81E6F334B000361DE /* retryWithBehavior.swift */,
@@ -593,6 +602,7 @@
 				538607C51E6F367A000361DE /* OnceTests.swift */,
 				5A1DDEB81ED58D2800F2E4B1 /* PausableBufferedTests.swift */,
 				538607C61E6F367A000361DE /* PausableTests.swift */,
+				783EDF8F232048E000F5C062 /* PausableAfterCountTests.swift */,
 				538607C71E6F367A000361DE /* RepeatWithBehaviorTests.swift */,
 				538607C81E6F367A000361DE /* RetryWithBehaviorTests.swift */,
 				780CB21820A0ED3B00FD3F39 /* ToSortedArrayTests.swift */,
@@ -1029,6 +1039,7 @@
 				538607AF1E6F334B000361DE /* ignoreErrors.swift in Sources */,
 				538607B91E6F334B000361DE /* unwrap.swift in Sources */,
 				538607B01E6F334B000361DE /* ignoreWhen.swift in Sources */,
+				783EDF8C2320462A00F5C062 /* pausableAfterCount.swift in Sources */,
 				538607AB1E6F334B000361DE /* cascade.swift in Sources */,
 				538607F01E6F589E000361DE /* not+RxCocoa.swift in Sources */,
 				538607B81E6F334B000361DE /* retryWithBehavior.swift in Sources */,
@@ -1099,6 +1110,7 @@
 				1958B5F621676ECB00CAF1D3 /* unrwapTests+SharedSequence.swift in Sources */,
 				C4D2154220118FB9009804AE /* Observable+OfTypeTests.swift in Sources */,
 				780CB21D20A0EE8300FD3F39 /* MapManyTests.swift in Sources */,
+				783EDF90232048E000F5C062 /* PausableAfterCountTests.swift in Sources */,
 				538607E41E6F36A9000361DE /* IgnoreTests.swift in Sources */,
 				538607E31E6F36A9000361DE /* IgnoreErrorsTests.swift in Sources */,
 				53C79D621E6F5B3900CD9B6A /* NotTests+RxCocoa.swift in Sources */,
@@ -1149,6 +1161,7 @@
 				A23E148821A9EFC000CD5B2F /* partition.swift in Sources */,
 				A23E148C21A9F03600CD5B2F /* partition+RxCocoa.swift in Sources */,
 				BF515CE81F3F3B0000492640 /* fromAsync.swift in Sources */,
+				783EDF8D2320462A00F5C062 /* pausableAfterCount.swift in Sources */,
 				BF515CEA1F3F3B0300492640 /* curry.swift in Sources */,
 				62512C691F0EAF850083A89F /* not+RxCocoa.swift in Sources */,
 				62512C6C1F0EAF950083A89F /* catchErrorJustComplete.swift in Sources */,
@@ -1199,6 +1212,7 @@
 				62512C991F0EB1850083A89F /* MapToTests.swift in Sources */,
 				3DBDE6001FBBB09A00DF47F9 /* AndTests.swift in Sources */,
 				58C54302EC14B6FF2034BAF6 /* ZipWithTest.swift in Sources */,
+				783EDF91232048E000F5C062 /* PausableAfterCountTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1236,6 +1250,7 @@
 				A23E148921A9EFC000CD5B2F /* partition.swift in Sources */,
 				A23E148D21A9F03600CD5B2F /* partition+RxCocoa.swift in Sources */,
 				BF515CE91F3F3B0100492640 /* fromAsync.swift in Sources */,
+				783EDF8E2320462A00F5C062 /* pausableAfterCount.swift in Sources */,
 				BF515CEB1F3F3B0300492640 /* curry.swift in Sources */,
 				E39C41DA1F18B086007F2ACD /* not+RxCocoa.swift in Sources */,
 				E39C41DD1F18B08A007F2ACD /* catchErrorJustComplete.swift in Sources */,
@@ -1286,6 +1301,7 @@
 				E39C42071F18B13E007F2ACD /* MapToTests.swift in Sources */,
 				3DBDE6011FBBB09A00DF47F9 /* AndTests.swift in Sources */,
 				58C54B6E1B4C678DE2378145 /* ZipWithTest.swift in Sources */,
+				783EDF92232048E000F5C062 /* PausableAfterCountTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/RxSwift/pausableAfterCount.swift
+++ b/Source/RxSwift/pausableAfterCount.swift
@@ -1,0 +1,69 @@
+//
+//  pausableAfterCount.swift
+//  RxSwiftExt
+//
+//  Created by Tanguy Helesbeux on 24/05/2017.
+//  Copyright © 2017 RxSwift Community. All rights reserved.
+//
+
+import Foundation
+import RxSwift
+
+extension ObservableType {
+
+    /**
+     Pauses the elements of the source observable sequence based on the latest element from the second observable sequence.
+
+     The pause is available only after a certain count of events. Before the number of emitted events reaches that count
+     the Pauser will not be taken care of. When the Pauser is active, elements are ignored unless the second sequence
+     has most recently emitted `true`.
+
+     - seealso: [pausable operator on reactivex.io](http://reactivex.io/documentation/operators/backpressure.html)
+
+     - Parameter count: the number of events before considering the pauser parameter
+     - parameter pauser: The observable sequence used to pause the source observable sequence.
+     - returns: The observable sequence which is paused based upon the pauser observable sequence.
+     */
+    public func pausable<P: ObservableType> (afterCount count: Int, withPauser pauser: P) -> Observable<E> where P.E == Bool {
+
+        return Observable<E>.create { observer in
+
+            let lock = NSRecursiveLock()
+            var paused = true
+            var elementIndex = 0
+
+            let pauserDisposable = pauser.subscribe { event in
+                lock.lock(); defer { lock.unlock() }
+                switch event {
+                case .next(let resume):
+                    paused = !resume
+                case .completed:
+                    observer.onCompleted()
+                case .error(let error):
+                    observer.onError(error)
+                }
+            }
+
+            let disposable = self.subscribe { event in
+                lock.lock(); defer { lock.unlock() }
+                switch event {
+                case .next(let element):
+
+                    if elementIndex < count {
+                        elementIndex += 1
+                        observer.onNext(element)
+                    } else if !paused {
+                        observer.onNext(element)
+                    }
+
+                case .completed:
+                    observer.onCompleted()
+                case .error(let error):
+                    observer.onError(error)
+                }
+            }
+
+            return Disposables.create([disposable, pauserDisposable])
+        }
+    }
+}

--- a/Source/RxSwift/pausableAfterCount.swift
+++ b/Source/RxSwift/pausableAfterCount.swift
@@ -24,46 +24,45 @@ extension ObservableType {
      - parameter pauser: The observable sequence used to pause the source observable sequence.
      - returns: The observable sequence which is paused based upon the pauser observable sequence.
      */
-    public func pausable<P: ObservableType> (afterCount count: Int, withPauser pauser: P) -> Observable<E> where P.E == Bool {
-
-        return Observable<E>.create { observer in
-
+    public func pausable<Pauser: ObservableType> (afterCount count: Int, withPauser pauser: Pauser)
+        -> Observable<Element> where Pauser.Element == Bool {
+        return .create { observer in
             let lock = NSRecursiveLock()
             var paused = true
             var elementIndex = 0
 
             let pauserDisposable = pauser.subscribe { event in
-                lock.lock(); defer { lock.unlock() }
+                lock.lock()
+                defer { lock.unlock() }
                 switch event {
-                case .next(let resume):
+                case let .next(resume):
                     paused = !resume
                 case .completed:
                     observer.onCompleted()
-                case .error(let error):
+                case let .error(error):
                     observer.onError(error)
                 }
             }
 
             let disposable = self.subscribe { event in
-                lock.lock(); defer { lock.unlock() }
+                lock.lock()
+                defer { lock.unlock() }
                 switch event {
-                case .next(let element):
-
+                case let .next(element):
                     if elementIndex < count {
                         elementIndex += 1
                         observer.onNext(element)
                     } else if !paused {
                         observer.onNext(element)
                     }
-
                 case .completed:
                     observer.onCompleted()
-                case .error(let error):
+                case let .error(error):
                     observer.onError(error)
                 }
             }
 
-            return Disposables.create([disposable, pauserDisposable])
+            return Disposables.create(disposable, disposable)
         }
     }
 }

--- a/Tests/RxSwift/PausableAfterCountTests.swift
+++ b/Tests/RxSwift/PausableAfterCountTests.swift
@@ -1,0 +1,105 @@
+//
+//  PausableAfterCountTests.swift
+//  RxSwiftExt
+//
+//  Created by Anton Nazarov on 04/09/2019.
+//  Copyright © 2019 RxSwift Community. All rights reserved.
+//
+
+import XCTest
+import RxSwift
+import RxSwiftExt
+import RxTest
+
+final class PausableAfterCountTests: XCTestCase {
+    private var scheduler: TestScheduler!
+
+    override func setUp() {
+        super.setUp()
+        scheduler = TestScheduler(initialClock: 0)
+    }
+
+    override func tearDown() {
+        scheduler = nil
+        super.tearDown()
+    }
+
+    func testNoSkipBeforeCount() {
+        // Given
+        let pauserEvents = Recorded.events(
+            .next(TestScheduler.Defaults.subscribed, true)
+        )
+        let expectedCompleted = 500
+        let events = Recorded.events(
+            .next(210, 2),
+            .next(230, 3),
+            .next(301, 4),
+            .next(350, 5),
+            .next(399, 6),
+            .completed(expectedCompleted)
+        )
+        let observable = scheduler.createHotObservable(events)
+        let pauser = scheduler.createHotObservable(pauserEvents)
+        // When
+        let sut = scheduler.start {
+            observable.pausable(afterCount: events.count, withPauser: pauser)
+        }
+        // Then
+        XCTAssertEqual(sut.events, events)
+        XCTAssertEqual(observable.subscriptions, [Subscription(TestScheduler.Defaults.subscribed, expectedCompleted)])
+    }
+
+    func testSkipAfterCount() {
+        // Given
+        let pauserEvents = Recorded.events(
+            .next(TestScheduler.Defaults.subscribed, true)
+        )
+        let expectedCompleted = 500
+        let events = Recorded.events(
+            .next(210, 2),
+            .next(230, 3),
+            .next(301, 4),
+            .next(350, 5),
+            .next(399, 6),
+            .completed(expectedCompleted)
+        )
+        let count = 3
+        let expectedEvents = Array(events.prefix(count)) + [.completed(expectedCompleted)]
+        let observable = scheduler.createHotObservable(events)
+        let pauser = scheduler.createHotObservable(pauserEvents)
+        // When
+        let sut = scheduler.start {
+            observable.pausable(afterCount: count, withPauser: pauser)
+        }
+        // Then
+        XCTAssertEqual(sut.events, expectedEvents)
+        XCTAssertEqual(observable.subscriptions, [Subscription(TestScheduler.Defaults.subscribed, expectedCompleted)])
+    }
+
+    func testPausedError() {
+        // Given
+        let pauserEvents = Recorded.events(
+            .next(TestScheduler.Defaults.subscribed, true)
+        )
+        let expectedError = 301
+        let events = Recorded.events(
+            .next(210, 2),
+            .next(230, 3),
+            .error(expectedError, testError),
+            .next(350, 5),
+            .next(399, 6),
+            .completed(500)
+        )
+        let count = 3
+        let expectedEvents = Array(events.prefix(count))
+        let observable = scheduler.createHotObservable(events)
+        let pauser = scheduler.createHotObservable(pauserEvents)
+        // When
+        let sut = scheduler.start {
+            observable.pausable(afterCount: count, withPauser: pauser)
+        }
+        // Then
+        XCTAssertEqual(sut.events, expectedEvents)
+        XCTAssertEqual(observable.subscriptions, [Subscription(TestScheduler.Defaults.subscribed, expectedError)])
+    }
+}


### PR DESCRIPTION
The pause is available only after a certain count of events. Before the number of emitted events reaches that count the Pauser will not be taken care of. When the Pauser is active, elements are ignored unless the second sequence has most recently emitted `true`, this becomes the same behavior as the normal pausable operator.