### PR TITLE
Deprecate mapTo() and mapAt() in favor to map(to:) and map(at:)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- deprecated `mapTo()` and `mapAt()` in favor of `map(to:)` and `map(at:)`
 - added `mapAt(keyPath:)` operator
 - added `zip(with:)` operator
 

--- a/Playground/RxSwiftExtPlayground.playground/Pages/mapAt.xcplaygroundpage/Contents.swift
+++ b/Playground/RxSwiftExtPlayground.playground/Pages/mapAt.xcplaygroundpage/Contents.swift
@@ -13,9 +13,9 @@ import RxSwift
 import RxSwiftExt
 
 /*:
- ## mapAt(KeyPath)
+ ## map(at: KeyPath)
 
- The `mapAt` operator transforms a sequence of elements where each element is mapped to its value at the provided key path
+ The `map(at:)` operator transforms a sequence of elements where each element is mapped to its value at the provided key path
  */
 example("map input to the value at provided key path") {
     struct Person {
@@ -29,7 +29,7 @@ example("map input to the value at provided key path") {
     ]
 
     Observable.from(people)
-        .mapAt(\.name)
+        .map(at: \.name)
         .toArray()
         .subscribe(onNext: {result in
             // look types on the right panel ===>

--- a/Playground/RxSwiftExtPlayground.playground/Pages/mapTo.xcplaygroundpage/Contents.swift
+++ b/Playground/RxSwiftExtPlayground.playground/Pages/mapTo.xcplaygroundpage/Contents.swift
@@ -15,13 +15,13 @@ import RxSwiftExt
 /*:
  ## map(to: Any)
  
- The `map` operator takes a sequence of elements and returns a sequence of the same constant provided as a parameter. In effect it ignores its input and replaces it with a constant
+ The `map(to:)` operator takes a sequence of elements and returns a sequence of the same constant provided as a parameter. In effect it ignores its input and replaces it with a constant
  */
 example("replace any input with a value") {
     
     let numbers = Array<Int?>([1, 2, 3])
     Observable.from(numbers)
-        .mapTo("candy")
+        .map(to: "candy")
         .toArray()
 		.subscribe(onNext: {result in
             // look types on the right panel ===>

--- a/Source/RxCocoa/mapTo+RxCocoa.swift
+++ b/Source/RxCocoa/mapTo+RxCocoa.swift
@@ -17,9 +17,15 @@ extension SharedSequenceConvertibleType {
      */
     @available(*, deprecated, renamed: "map(to:)")
     public func mapTo<R>(_ value: R) -> SharedSequence<SharingStrategy, R> {
-        return map { _ in value }
+        return map(to: value)
     }
 
+    /**
+     Returns an Unit containing as many elements as its input but all of them are the constant provided as a parameter
+
+     - parameter value: A constant that each element of the input sequence is being replaced with
+     - returns: An unit containing the values `value` provided as a parameter
+     */
     public func map<R>(to value: R) -> SharedSequence<SharingStrategy, R> {
         return map { _ in value }
     }

--- a/Source/RxSwift/mapAt.swift
+++ b/Source/RxSwift/mapAt.swift
@@ -16,7 +16,19 @@ extension ObservableType {
      - parameter keyPath: A key path whose root type matches the element type of the input sequence
      - returns: An observable squence containing the values pointed to by the key path
      */
+    @available(*, deprecated, renamed: "map(at:)")
     public func mapAt<R>(_ keyPath: KeyPath<E, R>) -> Observable<R> {
+        return self.map(at: keyPath)
+    }
+
+    /**
+     Returns an observable sequence containing as many elements as its input but all of them are mapped to the result at the given keyPath
+
+     - parameter keyPath: A key path whose root type matches the element type of the input sequence
+     - returns: An observable squence containing the values pointed to by the key path
+     */
+    public func map<R>(at keyPath: KeyPath<E, R>) -> Observable<R> {
         return self.map { $0[keyPath: keyPath] }
     }
+
 }

--- a/Source/RxSwift/mapTo.swift
+++ b/Source/RxSwift/mapTo.swift
@@ -17,7 +17,18 @@ extension ObservableType {
 	- parameter value: A constant that each element of the input sequence is being replaced with
 	- returns: An observable sequence containing the values `value` provided as a parameter
 	*/
-	public func mapTo<R>(_ value: R) -> Observable<R> {
+    @available(*, deprecated, renamed: "map(to:)")
+    public func mapTo<R>(_ value: R) -> Observable<R> {
+        return map(to: value)
+    }
+
+    /**
+     Returns an observable sequence containing as many elements as its input but all of them are the constant provided as a parameter
+
+     - parameter value: A constant that each element of the input sequence is being replaced with
+     - returns: An observable sequence containing the values `value` provided as a parameter
+     */
+	public func map<R>(to value: R) -> Observable<R> {
 		return map { _ in value }
 	}
 }

--- a/Tests/RxSwift/MapAtTests.swift
+++ b/Tests/RxSwift/MapAtTests.swift
@@ -1,5 +1,5 @@
 //
-//  MapToKeyPath.swift
+//  MapAtPath.swift
 //  RxSwiftExt-iOS
 //
 //  Created by Michael Avila on 2/8/18.
@@ -30,7 +30,7 @@ class MapAtTests: XCTestCase {
         observer = scheduler.createObserver(String.self)
 
         _ = Observable.from(people)
-            .mapAt(\.name)
+            .map(at: \.name)
             .subscribe(observer)
 
         scheduler.start()

--- a/Tests/RxSwift/mapToTests.swift
+++ b/Tests/RxSwift/mapToTests.swift
@@ -24,7 +24,7 @@ class MapToTests: XCTestCase {
         observer = scheduler.createObserver(String.self)
 
 		_ = Observable.from(numbers)
-            .mapTo("candy")
+            .map(to: "candy")
             .subscribe(observer)
 
         scheduler.start()


### PR DESCRIPTION
I noticed that `mapTo` was deprecated in favor to `map(to:)` on `SharedSequenceConvertibleType` (in **mapTo+RxCocoa.swift**), but this deprecation wasn't applied to `mapTo()` implementation on `ObservableType`. 
I thought it was great to uniforms this. I also deprecated new `mapAt()` in favor of `map(at:)` to keep some consistency.
