### PR TITLE
Soften RxSwift dependency for Carthage

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReactiveX/RxSwift" "4.0.0"
+github "ReactiveX/RxSwift" ~> 4.0


### PR DESCRIPTION
Just a small adjustment to the RxSwift required version. It should now use the latest version of RxSwift.  