### PR TITLE
Implement withUnretained operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 
 master
 -----
+- added `withUnretained(_:)` operator
 
 3.2.0
 -----

--- a/Playground/RxSwiftExtPlayground.playground/Pages/Index.xcplaygroundpage/Contents.swift
+++ b/Playground/RxSwiftExtPlayground.playground/Pages/Index.xcplaygroundpage/Contents.swift
@@ -23,6 +23,7 @@
  
  - [apply()](apply) operator, allows for factoring out repeated Observable chain transformations
  - [unwrap()](unwrap) operator, takes a sequence of optional elements and returns a sequence of non-optional elements, filtering out any `nil` values
+ - [withUnretained(_:)](withUnretained) operator provides an unretained, safe to use (i.e. not implicitly unwrapped), reference to an object along with the events emitted by the sequence.
  - [ignore(Any...)](ignore) operator, filters out any of the elements passed in parameters
  - [Observable.once(Element)](once) contructor, creates a sequence that delivers an element *once* to the first subscriber then completes. The same sequence will complete immediately without delivering any element to all further subscribers.
  - [mapAt(KeyPath)](mapAt) operator transforms a sequence of elements where each element is mapped to its value at the provided key path

--- a/Playground/RxSwiftExtPlayground.playground/Pages/withUnretained.xcplaygroundpage/Contents.swift
+++ b/Playground/RxSwiftExtPlayground.playground/Pages/withUnretained.xcplaygroundpage/Contents.swift
@@ -1,0 +1,51 @@
+/*:
+ > # IMPORTANT: To use `RxSwiftExtPlayground.playground`, please:
+ 
+ 1. Make sure you have [Carthage](https://github.com/Carthage/Carthage) installed
+ 1. Fetch Carthage dependencies from shell: `carthage bootstrap --platform ios`
+ 1. Build scheme `RxSwiftExtPlayground` scheme for a simulator target
+ 1. Choose `View > Show Debug Area`
+ */
+
+//: [Previous](@previous)
+
+import RxSwift
+import RxSwiftExt
+
+class Displayer {
+    init() { }
+    
+    deinit {
+        print("deinit")
+    }
+    
+    func display(_ value: Any) {
+        print(value)
+    }
+}
+
+example("withUnretained") {
+    let publishSubject = PublishSubject<Int>()
+    var displayer: Displayer? = Displayer()
+    
+    if let displayer = displayer {
+        _ = publishSubject
+            .withUnretained(displayer) // -> Observable<(Displayer, Int)>
+            .subscribe(onNext: { displayer, i in
+                displayer.display(i)
+            })
+    }
+    
+    publishSubject.onNext(1)
+    publishSubject.onNext(2)
+    publishSubject.onNext(3)
+    publishSubject.onNext(5)
+    publishSubject.onNext(8)
+    displayer = nil // the object referenced by `displayer` gets deallocated
+    publishSubject.onNext(13)
+    publishSubject.onNext(21)
+    publishSubject.onCompleted()
+}
+
+//: [Next](@next)
+

--- a/Playground/RxSwiftExtPlayground.playground/Pages/withUnretained.xcplaygroundpage/Contents.swift
+++ b/Playground/RxSwiftExtPlayground.playground/Pages/withUnretained.xcplaygroundpage/Contents.swift
@@ -12,40 +12,26 @@
 import RxSwift
 import RxSwiftExt
 
-class Displayer {
-    init() { }
-    
-    deinit {
-        print("deinit")
-    }
-    
-    func display(_ value: Any) {
-        print(value)
-    }
+class TestClass: CustomStringConvertible {
+    var description: String { return "Test Class" }
 }
 
 example("withUnretained") {
-    let publishSubject = PublishSubject<Int>()
-    var displayer: Displayer? = Displayer()
-    
-    if let displayer = displayer {
-        _ = publishSubject
-            .withUnretained(displayer) // -> Observable<(Displayer, Int)>
-            .subscribe(onNext: { displayer, i in
-                displayer.display(i)
-            })
-    }
-    
-    publishSubject.onNext(1)
-    publishSubject.onNext(2)
-    publishSubject.onNext(3)
-    publishSubject.onNext(5)
-    publishSubject.onNext(8)
-    displayer = nil // the object referenced by `displayer` gets deallocated
-    publishSubject.onNext(13)
-    publishSubject.onNext(21)
-    publishSubject.onCompleted()
-}
+    var testClass: TestClass! = TestClass()
 
+    _ = Observable
+        .of(1, 2, 3, 5, 8, 13, 18, 21, 23)
+        .withUnretained(testClass)
+        .debug("Combined Object with Emitted Events")
+        .do(onNext: { _, value in
+            if value == 13 {
+                // When testClass becomes nil, the next emission of the original
+                // sequence will try to retain it and fail. As soon as it fails,
+                // the sequence will complete.
+                testClass = nil
+            }
+        })
+        .subscribe()
+}
 //: [Next](@next)
 

--- a/Playground/RxSwiftExtPlayground.playground/contents.xcplayground
+++ b/Playground/RxSwiftExtPlayground.playground/contents.xcplayground
@@ -22,5 +22,6 @@
         <page name='nwise'/>
         <page name='zipWith'/>
         <page name='ofType'/>
+        <page name='withUnretained'/>
     </pages>
 </playground>

--- a/Readme.md
+++ b/Readme.md
@@ -69,6 +69,7 @@ RxSwiftExt is all about adding operators to [RxSwift](https://github.com/Reactiv
 * [filterMap](#filtermap)
 * [Observable.fromAsync](#fromasync)
 * [Observable.zip(with:)](#zipwith)
+* [withUnretained](#withunretained)
 
 Two additional operators are available for `materialize()`'d sequences:
 
@@ -510,6 +511,54 @@ next(5)
 completed
 ```
 This example emits 2, 5 (`NSDecimalNumber` Type).
+
+### withUnretained
+
+The `withUnretained(_:)` operator provides an unretained, safe to use (i.e. not implicitly unwrapped), reference to an object along with the values of the sequence.
+
+```swift
+class Displayer {
+    init() { }
+    
+    deinit {
+        print("deinit")
+    }
+    
+    func display(_ value: Any) {
+        print(value)
+    }
+}
+
+let publishSubject = PublishSubject<Int>()
+var displayer: Displayer? = Displayer()
+
+if let displayer = displayer {
+    _ = publishSubject
+        .withUnretained(displayer) // -> Observable<(Displayer, Int)>
+        .subscribe(onNext: { displayer, i in
+            displayer.display(i)
+        })
+}
+
+publishSubject.onNext(1)
+publishSubject.onNext(2)
+publishSubject.onNext(3)
+publishSubject.onNext(5)
+publishSubject.onNext(8)
+displayer = nil // the object referenced by `displayer` gets deallocated
+publishSubject.onNext(13)
+publishSubject.onNext(21)
+publishSubject.onCompleted()
+```
+
+```
+1
+2
+3
+5
+8
+deinit
+```
 
 ## License
 

--- a/Readme.md
+++ b/Readme.md
@@ -514,50 +514,36 @@ This example emits 2, 5 (`NSDecimalNumber` Type).
 
 ### withUnretained
 
-The `withUnretained(_:)` operator provides an unretained, safe to use (i.e. not implicitly unwrapped), reference to an object along with the values of the sequence.
+The `withUnretained(_:)` operator provides an unretained, safe to use (i.e. not implicitly unwrapped), reference to an object along with the events emitted by the sequence.
+In the case the provided object cannot be retained successfully, the seqeunce will complete.
 
 ```swift
-class Displayer {
-    init() { }
-    
-    deinit {
-        print("deinit")
-    }
-    
-    func display(_ value: Any) {
-        print(value)
-    }
+class TestClass: CustomStringConvertible {
+    var description: String { return "Test Class" }
 }
 
-let publishSubject = PublishSubject<Int>()
-var displayer: Displayer? = Displayer()
-
-if let displayer = displayer {
-    _ = publishSubject
-        .withUnretained(displayer) // -> Observable<(Displayer, Int)>
-        .subscribe(onNext: { displayer, i in
-            displayer.display(i)
-        })
-}
-
-publishSubject.onNext(1)
-publishSubject.onNext(2)
-publishSubject.onNext(3)
-publishSubject.onNext(5)
-publishSubject.onNext(8)
-displayer = nil // the object referenced by `displayer` gets deallocated
-publishSubject.onNext(13)
-publishSubject.onNext(21)
-publishSubject.onCompleted()
+Observable
+    .of(1, 2, 3, 5, 8, 13, 18, 21, 23)
+    .withUnretained(testClass)
+    .do(onNext: { _, value in
+        if value == 13 {
+            // When testClass becomes nil, the next emission of the original
+            // sequence will try to retain it and fail. As soon as it fails,
+            // the sequence will complete.
+            testClass = nil
+        }
+    })
+    .subscribe()
 ```
 
 ```
-1
-2
-3
-5
-8
-deinit
+next((Test Class, 1))
+next((Test Class, 2))
+next((Test Class, 3))
+next((Test Class, 5))
+next((Test Class, 8))
+next((Test Class, 13))
+completed
 ```
 
 ## License

--- a/RxSwiftExt.xcodeproj/project.pbxproj
+++ b/RxSwiftExt.xcodeproj/project.pbxproj
@@ -145,6 +145,12 @@
 		BF515CE91F3F3B0100492640 /* fromAsync.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF515CE11F3F371600492640 /* fromAsync.swift */; };
 		BF515CEA1F3F3B0300492640 /* curry.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF515CDF1F3F370600492640 /* curry.swift */; };
 		BF515CEB1F3F3B0300492640 /* curry.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF515CDF1F3F370600492640 /* curry.swift */; };
+		BF79DA0A206C145D008AA708 /* withUnretained.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF79DA09206C145D008AA708 /* withUnretained.swift */; };
+		BF79DA0B206C145D008AA708 /* withUnretained.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF79DA09206C145D008AA708 /* withUnretained.swift */; };
+		BF79DA0C206C145D008AA708 /* withUnretained.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF79DA09206C145D008AA708 /* withUnretained.swift */; };
+		BF79DA0E206C185B008AA708 /* WithUnretainedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF79DA0D206C185B008AA708 /* WithUnretainedTests.swift */; };
+		BF79DA0F206C185B008AA708 /* WithUnretainedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF79DA0D206C185B008AA708 /* WithUnretainedTests.swift */; };
+		BF79DA10206C185B008AA708 /* WithUnretainedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF79DA0D206C185B008AA708 /* WithUnretainedTests.swift */; };
 		C4D2153F20118A81009804AE /* ofType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D2153E20118A81009804AE /* ofType.swift */; };
 		C4D2154220118FB9009804AE /* Observable+OfTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D2154020118F8B009804AE /* Observable+OfTypeTests.swift */; };
 		C4D2154320118FB9009804AE /* Observable+OfTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D2154020118F8B009804AE /* Observable+OfTypeTests.swift */; };
@@ -302,6 +308,8 @@
 		BF515CDF1F3F370600492640 /* curry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = curry.swift; path = Source/Tools/curry.swift; sourceTree = SOURCE_ROOT; };
 		BF515CE11F3F371600492640 /* fromAsync.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = fromAsync.swift; path = Source/RxSwift/fromAsync.swift; sourceTree = SOURCE_ROOT; };
 		BF515CE31F3F3AC900492640 /* FromAsyncTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FromAsyncTests.swift; sourceTree = "<group>"; };
+		BF79DA09206C145D008AA708 /* withUnretained.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = withUnretained.swift; sourceTree = "<group>"; };
+		BF79DA0D206C185B008AA708 /* WithUnretainedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithUnretainedTests.swift; sourceTree = "<group>"; };
 		C4D2153E20118A81009804AE /* ofType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ofType.swift; sourceTree = "<group>"; };
 		C4D2154020118F8B009804AE /* Observable+OfTypeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Observable+OfTypeTests.swift"; sourceTree = "<group>"; };
 		D7C72A3D1FDC5C5D00EAAAAB /* NwiseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NwiseTests.swift; sourceTree = "<group>"; };
@@ -464,6 +472,7 @@
 				538607A91E6F334B000361DE /* unwrap.swift */,
 				58C54402C636BC3C2F36A4ED /* zipWith.swift */,
 				C4D2153E20118A81009804AE /* ofType.swift */,
+				BF79DA09206C145D008AA708 /* withUnretained.swift */,
 			);
 			path = RxSwift;
 			sourceTree = "<group>";
@@ -496,6 +505,7 @@
 				538607CA1E6F367A000361DE /* WeakTarget.swift */,
 				538607CB1E6F367A000361DE /* WeakTests.swift */,
 				58C54E184069446EDEE748F9 /* ZipWithTest.swift */,
+				BF79DA0D206C185B008AA708 /* WithUnretainedTests.swift */,
 			);
 			name = RxSwift;
 			path = Tests/RxSwift;
@@ -937,6 +947,7 @@
 				98309EB11EDF159500BD07D9 /* filterMap.swift in Sources */,
 				53F336E81E70CBF700D35D38 /* distinct+RxCocoa.swift in Sources */,
 				538607AE1E6F334B000361DE /* ignore.swift in Sources */,
+				BF79DA0A206C145D008AA708 /* withUnretained.swift in Sources */,
 				BF515CE01F3F370600492640 /* curry.swift in Sources */,
 				5A1DDEBF1ED58F8600F2E4B1 /* pausableBuffered.swift in Sources */,
 				BF515CE21F3F371600492640 /* fromAsync.swift in Sources */,
@@ -963,6 +974,7 @@
 				538607E21E6F36A9000361DE /* DistinctTests.swift in Sources */,
 				538607EA1E6F36A9000361DE /* PausableTests.swift in Sources */,
 				538607E91E6F36A9000361DE /* OnceTests.swift in Sources */,
+				BF79DA0E206C185B008AA708 /* WithUnretainedTests.swift in Sources */,
 				538607EE1E6F36A9000361DE /* WeakTests.swift in Sources */,
 				538607E51E6F36A9000361DE /* IgnoreWhenTests.swift in Sources */,
 				538607E11E6F36A9000361DE /* CatchErrorJustCompleteTests.swift in Sources */,
@@ -1008,6 +1020,7 @@
 				62512C7B1F0EAF950083A89F /* flatMapSync.swift in Sources */,
 				62512C681F0EAF850083A89F /* mapTo+RxCocoa.swift in Sources */,
 				62512C791F0EAF950083A89F /* retryWithBehavior.swift in Sources */,
+				BF79DA0B206C145D008AA708 /* withUnretained.swift in Sources */,
 				BF515CE81F3F3B0000492640 /* fromAsync.swift in Sources */,
 				BF515CEA1F3F3B0300492640 /* curry.swift in Sources */,
 				62512C691F0EAF850083A89F /* not+RxCocoa.swift in Sources */,
@@ -1034,6 +1047,7 @@
 				62512C8F1F0EB17A0083A89F /* DistinctTests+RxCocoa.swift in Sources */,
 				62512C951F0EB1850083A89F /* DistinctTests.swift in Sources */,
 				62512CA11F0EB1850083A89F /* UnwrapTests.swift in Sources */,
+				BF79DA0F206C185B008AA708 /* WithUnretainedTests.swift in Sources */,
 				62512CA31F0EB1850083A89F /* WeakTests.swift in Sources */,
 				62512C981F0EB1850083A89F /* IgnoreWhenTests.swift in Sources */,
 				62512C9E1F0EB1850083A89F /* PausableBufferedTests.swift in Sources */,
@@ -1079,6 +1093,7 @@
 				E39C41EC1F18B08A007F2ACD /* flatMapSync.swift in Sources */,
 				E39C41D91F18B086007F2ACD /* mapTo+RxCocoa.swift in Sources */,
 				E39C41EA1F18B08A007F2ACD /* retryWithBehavior.swift in Sources */,
+				BF79DA0C206C145D008AA708 /* withUnretained.swift in Sources */,
 				BF515CE91F3F3B0100492640 /* fromAsync.swift in Sources */,
 				BF515CEB1F3F3B0300492640 /* curry.swift in Sources */,
 				E39C41DA1F18B086007F2ACD /* not+RxCocoa.swift in Sources */,
@@ -1105,6 +1120,7 @@
 				E39C42011F18B13E007F2ACD /* CascadeTests.swift in Sources */,
 				E39C42101F18B13E007F2ACD /* WeakTarget.swift in Sources */,
 				E39C42031F18B13E007F2ACD /* DistinctTests.swift in Sources */,
+				BF79DA10206C185B008AA708 /* WithUnretainedTests.swift in Sources */,
 				E39C41FD1F18B13A007F2ACD /* DistinctTests+RxCocoa.swift in Sources */,
 				E39C42051F18B13E007F2ACD /* IgnoreTests.swift in Sources */,
 				E39C420E1F18B13E007F2ACD /* RetryWithBehaviorTests.swift in Sources */,

--- a/Source/RxSwift/withUnretained.swift
+++ b/Source/RxSwift/withUnretained.swift
@@ -1,0 +1,45 @@
+//
+//  withUnretained.swift
+//  RxSwiftExt
+//
+//  Created by Vincent Pradeilles on 28/03/2018.
+//  Copyright © 2018 RxSwiftCommunity. All rights reserved.
+//
+
+import RxSwift
+
+private enum UnretainedError : Swift.Error {
+    case objectReleased
+}
+
+extension ObservableType {
+    /**
+     Provides an unretained, safe to use (i.e. not implicitly unwrapped), reference to an object along with the values of the sequence
+     
+     - parameter obj: The object to provide an unretained reference on.
+     - parameter resultSelector: A function to combine the unretained referenced on `obj` and the value of the observable sequence.
+     - returns: An observable sequence that contains the result of `resultSelector` being called with an unretained reference on `obj` and the values of the original sequence.
+     */
+    public func withUnretained<T : AnyObject, Out>(_ obj: T, resultSelector: @escaping (T, Self.E) -> Out) -> Observable<Out> {
+        return map { [weak obj] element -> Out in
+            guard let obj = obj else { throw UnretainedError.objectReleased }
+            
+            return resultSelector(obj, element)
+            }
+            .catchError { error -> Observable<Out> in
+                if (error as? UnretainedError) == UnretainedError.objectReleased {
+                    return .empty()
+                }
+                return Observable.error(error)
+        }
+    }
+    /**
+     Provides an unretained, safe to use (i.e. not implicitly unwrapped), reference to an object along with the values of the sequence
+     
+     - parameter obj: The object to provide an unretained reference on.
+     - returns: An observable sequence of tuples that contains both an unretained reference on `obj` and the values of the original sequence.
+     */
+    public func withUnretained<T : AnyObject>(_ obj: T) -> Observable<(T, Self.E)> {
+        return withUnretained(obj, resultSelector: { obj, element in (obj, element) })
+    }
+}

--- a/Source/RxSwift/withUnretained.swift
+++ b/Source/RxSwift/withUnretained.swift
@@ -8,38 +8,44 @@
 
 import RxSwift
 
-private enum UnretainedError : Swift.Error {
-    case objectReleased
-}
-
 extension ObservableType {
     /**
-     Provides an unretained, safe to use (i.e. not implicitly unwrapped), reference to an object along with the values of the sequence
+     Provides an unretained, safe to use (i.e. not implicitly unwrapped), reference to an object along with the events emitted by the sequence.
+     In the case the provided object cannot be retained successfully, the seqeunce will complete.
      
      - parameter obj: The object to provide an unretained reference on.
      - parameter resultSelector: A function to combine the unretained referenced on `obj` and the value of the observable sequence.
      - returns: An observable sequence that contains the result of `resultSelector` being called with an unretained reference on `obj` and the values of the original sequence.
      */
-    public func withUnretained<T : AnyObject, Out>(_ obj: T, resultSelector: @escaping (T, Self.E) -> Out) -> Observable<Out> {
+    public func withUnretained<T: AnyObject, Out>(_ obj: T,
+                                                  resultSelector: @escaping (T, Self.E) -> Out) -> Observable<Out> {
         return map { [weak obj] element -> Out in
-            guard let obj = obj else { throw UnretainedError.objectReleased }
-            
+            guard let obj = obj else { throw UnretainedError.failedRetaining }
+
             return resultSelector(obj, element)
+        }
+        .catchError { error -> Observable<Out> in
+            guard let unretainedError = error as? UnretainedError,
+                  unretainedError == .failedRetaining else {
+                return .error(error)
             }
-            .catchError { error -> Observable<Out> in
-                if (error as? UnretainedError) == UnretainedError.objectReleased {
-                    return .empty()
-                }
-                return Observable.error(error)
+
+            return .empty()
         }
     }
+
     /**
-     Provides an unretained, safe to use (i.e. not implicitly unwrapped), reference to an object along with the values of the sequence
+     Provides an unretained, safe to use (i.e. not implicitly unwrapped), reference to an object along with the events emitted by the sequence.
+     In the case the provided object cannot be retained successfully, the seqeunce will complete.
      
      - parameter obj: The object to provide an unretained reference on.
      - returns: An observable sequence of tuples that contains both an unretained reference on `obj` and the values of the original sequence.
      */
-    public func withUnretained<T : AnyObject>(_ obj: T) -> Observable<(T, Self.E)> {
-        return withUnretained(obj, resultSelector: { obj, element in (obj, element) })
+    public func withUnretained<T: AnyObject>(_ obj: T) -> Observable<(T, Self.E)> {
+        return withUnretained(obj) { ($0, $1) }
     }
+}
+
+private enum UnretainedError: Swift.Error {
+    case failedRetaining
 }

--- a/Source/RxSwift/withUnretained.swift
+++ b/Source/RxSwift/withUnretained.swift
@@ -3,7 +3,7 @@
 //  RxSwiftExt
 //
 //  Created by Vincent Pradeilles on 28/03/2018.
-//  Copyright © 2018 RxSwiftCommunity. All rights reserved.
+//  Copyright © 2018 RxSwift Community. All rights reserved.
 //
 
 import RxSwift

--- a/Tests/RxSwift/WithUnretainedTests.swift
+++ b/Tests/RxSwift/WithUnretainedTests.swift
@@ -10,89 +10,115 @@ import XCTest
 import RxSwift
 import RxTest
 
-private class Displayer {
-    let deinitAction: (() -> Void)?
+class WithUnretainedTests: XCTestCase {
+    fileprivate var testClass: TestClass!
+    var values: TestableObservable<Int>!
+    var tupleValues: TestableObservable<(Int, String)>!
+    let scheduler = TestScheduler(initialClock: 0)
 
-    init(deinitAction: (() -> Void)? = nil) {
-        self.deinitAction = deinitAction
+    override func setUp() {
+        super.setUp()
+
+        testClass = TestClass()
+        values = scheduler.createColdObservable([
+            .next(210, 1),
+            .next(215, 2),
+            .next(220, 3),
+            .next(225, 5),
+            .next(230, 8),
+            completed(250)
+        ])
+
+        tupleValues = scheduler.createColdObservable([
+            .next(210, (1, "a")),
+            .next(215, (2, "b")),
+            .next(220, (3, "c")),
+            .next(225, (5, "d")),
+            .next(230, (8, "e")),
+            completed(250)
+        ])
     }
 
-    deinit {
-        deinitAction?()
+    func testObjectAttached() {
+        let testClassId = testClass.id
+
+        let correctValues: [Recorded<Event<String>>] = [
+            .next(410, "\(testClassId), 1"),
+            .next(415, "\(testClassId), 2"),
+            .next(420, "\(testClassId), 3"),
+            .next(425, "\(testClassId), 5"),
+            .next(430, "\(testClassId), 8"),
+            completed(450)
+        ]
+
+        let res = scheduler.start {
+            self.values
+                .withUnretained(self.testClass)
+                .map { "\($0.0.id), \($0.1)" }
+        }
+
+        XCTAssertEqual(res.events, correctValues)
     }
 
-    func display(_ value: Any) {
-        print(value)
+    func testObjectDeallocates() {
+        _ = self.values
+                .withUnretained(self.testClass)
+                .subscribe()
+
+        // Confirm the object can be deallocated
+        XCTAssertTrue(testClass != nil)
+        testClass = nil
+        XCTAssertTrue(testClass == nil)
+    }
+
+    func testObjectDeallocatesSequenceCompletes() {
+        let testClassId = testClass.id
+
+        let correctValues: [Recorded<Event<String>>] = [
+            .next(410, "\(testClassId), 1"),
+            .next(415, "\(testClassId), 2"),
+            .next(420, "\(testClassId), 3"),
+            completed(425)
+        ]
+
+        let res = scheduler.start {
+            self.values
+                .withUnretained(self.testClass)
+                .do(onNext: { _, value in
+                    // Release the object in the middle of the sequence
+                    // to confirm it properly terminates the sequence
+                    if value == 3 {
+                        self.testClass = nil
+                    }
+                })
+                .map { "\($0.0.id), \($0.1)" }
+        }
+
+        XCTAssertEqual(res.events, correctValues)
+    }
+
+    func testResultsSelector() {
+        let testClassId = testClass.id
+
+        let correctValues: [Recorded<Event<String>>] = [
+            .next(410, "\(testClassId), 1, a"),
+            .next(415, "\(testClassId), 2, b"),
+            .next(420, "\(testClassId), 3, c"),
+            .next(425, "\(testClassId), 5, d"),
+            .next(430, "\(testClassId), 8, e"),
+            completed(450)
+        ]
+
+        let res = scheduler.start {
+            self.tupleValues
+                .withUnretained(self.testClass) { ($0, $1.0, $1.1) }
+                .map { "\($0.0.id), \($0.1), \($0.2)" }
+        }
+
+        XCTAssertEqual(res.events, correctValues)
     }
 }
 
-class WithUnretainedTests: XCTestCase {
-    func test_unretained_gets_deallocated() {
-        // Test constants
-        let valuesToBeObserved = [1, 2, 3, 5, 8]
-        let valuesToBeIgnored = [13, 21]
-
-        // Test flags
-        var displayerWasDeallocated = false
-        var valuesObserved = [Int]()
-
-        // Object to be safely unowned
-        var displayer: Displayer? = Displayer(deinitAction: {
-            displayerWasDeallocated = true
-        })
-
-        let publishSubject = PublishSubject<Int>()
-
-        if let displayer = displayer {
-            _ = publishSubject
-                .withUnretained(displayer) // -> Observable<(Displayer, Int)>
-                .subscribe(onNext: { displayer, i in
-                    displayer.display(i)
-                    valuesObserved.append(i)
-                })
-        }
-
-        valuesToBeObserved.forEach { publishSubject.onNext($0) }
-        displayer = nil
-        valuesToBeIgnored.forEach { publishSubject.onNext($0) }
-        publishSubject.onCompleted()
-
-        XCTAssertTrue(displayerWasDeallocated)
-        XCTAssertEqual(valuesObserved, valuesToBeObserved)
-    }
-
-    func test_sequence_completes() {
-        // Test constants
-        let valuesToBeObserved = [1, 2, 3, 5, 8]
-        let valuesToBeIgnored = [13, 21]
-
-        // Test flags
-        var outerSequenceHasCompleted = false
-        var valuesObserved = [Int]()
-
-        // Object to be safely unowned
-        var displayer: Displayer? = Displayer()
-
-        let publishSubject = PublishSubject<Int>()
-
-        if let displayer = displayer {
-            _ = publishSubject
-                .withUnretained(displayer) // -> Observable<(Displayer, Int)>
-                .debug()
-                .subscribe(onNext: { displayer, i in
-                    displayer.display(i)
-                    valuesObserved.append(i)
-                }, onError: nil,
-                   onCompleted: {
-                    outerSequenceHasCompleted = true
-                }, onDisposed: nil)
-        }
-
-        valuesToBeObserved.forEach { publishSubject.onNext($0) }
-        displayer = nil
-        valuesToBeIgnored.forEach { publishSubject.onNext($0) }
-
-        XCTAssertTrue(outerSequenceHasCompleted)
-        XCTAssertEqual(valuesObserved, valuesToBeObserved)
-    }
+private class TestClass {
+    let id: String = UUID().uuidString
 }

--- a/Tests/RxSwift/WithUnretainedTests.swift
+++ b/Tests/RxSwift/WithUnretainedTests.swift
@@ -1,0 +1,100 @@
+//
+//  WithUnretainedTests.swift
+//  RxSwiftExt
+//
+//  Created by Vincent Pradeilles on 28/03/2018.
+//  Copyright © 2018 RxSwiftCommunity. All rights reserved.
+//
+
+import XCTest
+import RxSwift
+import RxTest
+
+private class Displayer {
+    
+    let deinitAction: (() -> Void)?
+    
+    init(deinitAction: (() -> Void)? = nil) {
+        self.deinitAction = deinitAction
+    }
+    
+    deinit {
+        deinitAction?()
+    }
+    
+    func display(_ value: Any) {
+        print(value)
+    }
+}
+
+class WithUnretainedTests: XCTestCase {
+    
+    func test_unretained_gets_deallocated() {
+        // Test constants
+        let valuesToBeObserved = [1, 2, 3, 5, 8]
+        let valuesToBeIgnored = [13, 21]
+        
+        // Test flags
+        var displayerWasDeallocated = false
+        var valuesObserved = [Int]()
+        
+        // Object to be safely unowned
+        var displayer: Displayer? = Displayer(deinitAction: {
+            displayerWasDeallocated = true
+        })
+        
+        let publishSubject = PublishSubject<Int>()
+        
+        if let displayer = displayer {
+            _ = publishSubject
+                .withUnretained(displayer) // -> Observable<(Displayer, Int)>
+                .subscribe(onNext: { displayer, i in
+                    displayer.display(i)
+                    valuesObserved.append(i)
+                })
+        }
+        
+        valuesToBeObserved.forEach { publishSubject.onNext($0) }
+        displayer = nil
+        valuesToBeIgnored.forEach { publishSubject.onNext($0) }
+        publishSubject.onCompleted()
+        
+        XCTAssertTrue(displayerWasDeallocated)
+        XCTAssertEqual(valuesObserved, valuesToBeObserved)
+    }
+    
+    func test_sequence_completes() {
+        // Test constants
+        let valuesToBeObserved = [1, 2, 3, 5, 8]
+        let valuesToBeIgnored = [13, 21]
+        
+        // Test flags
+        var outerSequenceHasCompleted = false
+        var valuesObserved = [Int]()
+        
+        // Object to be safely unowned
+        var displayer: Displayer? = Displayer()
+        
+        let publishSubject = PublishSubject<Int>()
+        
+        if let displayer = displayer {
+            _ = publishSubject
+                .withUnretained(displayer) // -> Observable<(Displayer, Int)>
+                .debug()
+                .subscribe(onNext: { displayer, i in
+                    displayer.display(i)
+                    valuesObserved.append(i)
+                }, onError: nil,
+                   onCompleted: {
+                    outerSequenceHasCompleted = true
+                }, onDisposed: nil)
+        }
+        
+        valuesToBeObserved.forEach { publishSubject.onNext($0) }
+        displayer = nil
+        valuesToBeIgnored.forEach { publishSubject.onNext($0) }
+        
+        XCTAssertTrue(outerSequenceHasCompleted)
+        XCTAssertEqual(valuesObserved, valuesToBeObserved)
+    }
+}

--- a/Tests/RxSwift/WithUnretainedTests.swift
+++ b/Tests/RxSwift/WithUnretainedTests.swift
@@ -3,7 +3,7 @@
 //  RxSwiftExt
 //
 //  Created by Vincent Pradeilles on 28/03/2018.
-//  Copyright © 2018 RxSwiftCommunity. All rights reserved.
+//  Copyright © 2018 RxSwift Community. All rights reserved.
 //
 
 import XCTest
@@ -11,40 +11,38 @@ import RxSwift
 import RxTest
 
 private class Displayer {
-    
     let deinitAction: (() -> Void)?
-    
+
     init(deinitAction: (() -> Void)? = nil) {
         self.deinitAction = deinitAction
     }
-    
+
     deinit {
         deinitAction?()
     }
-    
+
     func display(_ value: Any) {
         print(value)
     }
 }
 
 class WithUnretainedTests: XCTestCase {
-    
     func test_unretained_gets_deallocated() {
         // Test constants
         let valuesToBeObserved = [1, 2, 3, 5, 8]
         let valuesToBeIgnored = [13, 21]
-        
+
         // Test flags
         var displayerWasDeallocated = false
         var valuesObserved = [Int]()
-        
+
         // Object to be safely unowned
         var displayer: Displayer? = Displayer(deinitAction: {
             displayerWasDeallocated = true
         })
-        
+
         let publishSubject = PublishSubject<Int>()
-        
+
         if let displayer = displayer {
             _ = publishSubject
                 .withUnretained(displayer) // -> Observable<(Displayer, Int)>
@@ -53,30 +51,30 @@ class WithUnretainedTests: XCTestCase {
                     valuesObserved.append(i)
                 })
         }
-        
+
         valuesToBeObserved.forEach { publishSubject.onNext($0) }
         displayer = nil
         valuesToBeIgnored.forEach { publishSubject.onNext($0) }
         publishSubject.onCompleted()
-        
+
         XCTAssertTrue(displayerWasDeallocated)
         XCTAssertEqual(valuesObserved, valuesToBeObserved)
     }
-    
+
     func test_sequence_completes() {
         // Test constants
         let valuesToBeObserved = [1, 2, 3, 5, 8]
         let valuesToBeIgnored = [13, 21]
-        
+
         // Test flags
         var outerSequenceHasCompleted = false
         var valuesObserved = [Int]()
-        
+
         // Object to be safely unowned
         var displayer: Displayer? = Displayer()
-        
+
         let publishSubject = PublishSubject<Int>()
-        
+
         if let displayer = displayer {
             _ = publishSubject
                 .withUnretained(displayer) // -> Observable<(Displayer, Int)>
@@ -89,11 +87,11 @@ class WithUnretainedTests: XCTestCase {
                     outerSequenceHasCompleted = true
                 }, onDisposed: nil)
         }
-        
+
         valuesToBeObserved.forEach { publishSubject.onNext($0) }
         displayer = nil
         valuesToBeIgnored.forEach { publishSubject.onNext($0) }
-        
+
         XCTAssertTrue(outerSequenceHasCompleted)
         XCTAssertEqual(valuesObserved, valuesToBeObserved)
     }


### PR DESCRIPTION
The `withUnowned(_:)` operator provides an unowned, safe to use (i.e. not implicitly unwrapped), reference to an object along with the values of the sequence.

```swift
class Displayer {
    init() { }
    
    deinit {
        print("deinit")
    }
    
    func display(_ value: Any) {
        print(value)
    }
}

let publishSubject = PublishSubject<Int>()
var displayer: Displayer? = Displayer()

if let displayer = displayer {
    _ = publishSubject
        .withUnowned(displayer) // -> Observable<(Displayer, Int)>
        .subscribe(onNext: { displayer, i in
            displayer.display(i)
        })
}

publishSubject.onNext(1)
publishSubject.onNext(2)
publishSubject.onNext(3)
publishSubject.onNext(5)
publishSubject.onNext(8)
displayer = nil // the object referenced by `displayer` gets deallocated
publishSubject.onNext(13)
publishSubject.onNext(21)
publishSubject.onCompleted()
```

```
1
2
3
5
8
deinit
```
