### PR TITLE
Make withUnretained explicitly use a selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 
 master
 -----
+- Fix `withUnretained` so it allows proper destructuring
 - added `mapMany` operator
 - added `toSortedArray` operator
 

--- a/Source/RxSwift/withUnretained.swift
+++ b/Source/RxSwift/withUnretained.swift
@@ -18,11 +18,11 @@ extension ObservableType {
      - returns: An observable sequence that contains the result of `resultSelector` being called with an unretained reference on `obj` and the values of the original sequence.
      */
     public func withUnretained<T: AnyObject, Out>(_ obj: T,
-                                                  resultSelector: @escaping (T, Self.E) -> Out) -> Observable<Out> {
+                                                  resultSelector: @escaping ((T, Self.E)) -> Out) -> Observable<Out> {
         return map { [weak obj] element -> Out in
             guard let obj = obj else { throw UnretainedError.failedRetaining }
 
-            return resultSelector(obj, element)
+            return resultSelector((obj, element))
         }
         .catchError { error -> Observable<Out> in
             guard let unretainedError = error as? UnretainedError,

--- a/Tests/RxSwift/WithUnretainedTests.swift
+++ b/Tests/RxSwift/WithUnretainedTests.swift
@@ -54,7 +54,7 @@ class WithUnretainedTests: XCTestCase {
         let res = scheduler.start {
             self.values
                 .withUnretained(self.testClass)
-                .map { "\($0.0.id), \($0.1)" }
+                .map { "\($0.id), \($1)" }
         }
 
         XCTAssertEqual(res.events, correctValues)
@@ -91,7 +91,7 @@ class WithUnretainedTests: XCTestCase {
                         self.testClass = nil
                     }
                 })
-                .map { "\($0.0.id), \($0.1)" }
+                .map { "\($0.id), \($1)" }
         }
 
         XCTAssertEqual(res.events, correctValues)
@@ -112,7 +112,7 @@ class WithUnretainedTests: XCTestCase {
         let res = scheduler.start {
             self.tupleValues
                 .withUnretained(self.testClass) { ($0, $1.0, $1.1) }
-                .map { "\($0.0.id), \($0.1), \($0.2)" }
+                .map { "\($0.id), \($1), \($2)" }
         }
 
         XCTAssertEqual(res.events, correctValues)


### PR DESCRIPTION
This is based on a change in [SE-0110](https://github.com/apple/swift-evolution/blob/master/proposals/0110-distingish-single-tuple-arg.md) 

the gist is, in the existing implementation you can’t do 

```swift
.withUnretained(self)
.flatMap { owner, value in … }
```

Since a single parentheses pair is not considered an explicit tuple, so does not support splatting correctly. 

Without this change you have to do

```swift
.withUnretained(self)
.flatMap { tuple in … tuple.0, tuple.1 }
```

This retains backward compatibility with the explicit `tuple.0` implementation, so there are no breaking changes here. 

Thanks to @sgtsquiggs for noticing this. 