### PR TITLE
Roll `map(to:)` back to `mapTo(_:)` for `SharedSequenceConvertibleType`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ master
 - Fix `withUnretained` so it allows proper destructuring
 - added `mapMany` operator
 - added `toSortedArray` operator
+- rolled `map(to:)` back to `mapTo(_:)` for `SharedSequenceConvertibleType`
 
 3.3.0
 -----

--- a/Source/RxCocoa/mapTo+RxCocoa.swift
+++ b/Source/RxCocoa/mapTo+RxCocoa.swift
@@ -15,12 +15,7 @@ extension SharedSequenceConvertibleType {
      - parameter value: A constant that each element of the input sequence is being replaced with
      - returns: An unit containing the values `value` provided as a parameter
      */
-    @available(*, deprecated, renamed: "map(to:)")
     public func mapTo<R>(_ value: R) -> SharedSequence<SharingStrategy, R> {
-        return map { _ in value }
-    }
-
-    public func map<R>(to value: R) -> SharedSequence<SharingStrategy, R> {
         return map { _ in value }
     }
 }

--- a/Source/RxCocoa/mapTo+RxCocoa.swift
+++ b/Source/RxCocoa/mapTo+RxCocoa.swift
@@ -18,4 +18,9 @@ extension SharedSequenceConvertibleType {
     public func mapTo<R>(_ value: R) -> SharedSequence<SharingStrategy, R> {
         return map { _ in value }
     }
+    
+    @available(*, deprecated, renamed: "mapTo(_:)")
+    public func map<R>(to value: R) -> SharedSequence<SharingStrategy, R> {
+        return map { _ in value }
+    }
 }

--- a/Tests/RxCocoa/MapToTests+RxCocoa.swift
+++ b/Tests/RxCocoa/MapToTests+RxCocoa.swift
@@ -25,7 +25,7 @@ class MapToCocoaTests: XCTestCase {
 
         _ = Observable.from(numbers)
             .asDriver(onErrorJustReturn: nil)
-            .map(to: "candy")
+            .mapTo("candy")
             .drive(observer)
 
         scheduler.start()


### PR DESCRIPTION
The `map(to:)` function was rolled back to the name `mapTo(_:)` for `ObservableType` in https://github.com/RxSwiftCommunity/RxSwiftExt/pull/121. The change wasn't made for `SharedSequenceConvertibleType`, though.

So, now I have a project with a bunch of `map(to:)`s and `mapTo(_:)`s 🙃.

It would be nice to have convergence here!