### PR TITLE
maybe: add a ifEmpty(switchToSingleWithError:) extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ master
 - added `mapMany` operator
 - added `toSortedArray` operator
 - rolled `map(to:)` back to `mapTo(_:)` for `SharedSequenceConvertibleType`
+- added `ifEmpty(switchToSingleWithError:)` to the trait `Maybe`
 
 3.3.0
 -----

--- a/Playground/RxSwiftExtPlayground.playground/Pages/ifEmptySwitchToError.xcplaygroundpage/Contents.swift
+++ b/Playground/RxSwiftExtPlayground.playground/Pages/ifEmptySwitchToError.xcplaygroundpage/Contents.swift
@@ -1,0 +1,39 @@
+/*:
+ > # IMPORTANT: To use `RxSwiftExtPlayground.playground`, please:
+
+ 1. Make sure you have [Carthage](https://github.com/Carthage/Carthage) installed
+ 1. Fetch Carthage dependencies from shell: `carthage bootstrap --platform ios`
+ 1. Build scheme `RxSwiftExtPlayground` scheme for a simulator target
+ 1. Choose `View > Show Debug Area`
+ */
+
+//: [Previous](@previous)
+
+import RxSwift
+import RxSwiftExt
+
+/*:
+ ## ifEmpty(switchToSingleWithError:)
+ In case The Maybe is empty, it is transformed in a Single that immediately triggers an Error
+
+ */
+
+enum SwitchToSingleWithError: Error {
+    case completedError
+}
+
+example("Maybe switched to Error if empty") {
+
+    Maybe<Bool>.create(subscribe: { (observer) -> Disposable in
+        observer(.completed)
+        return Disposables.create()
+    })
+        .ifEmpty(switchToSingleWithError: SwitchToSingleWithError.completedError)
+        .subscribe(onSuccess: { (value) in
+            print ("The value will never be emitted since the Maybe completes")
+        }, onError: { (error) in
+            print ("The completed event is transformed into this error: \(error)")
+        })
+}
+
+//: [Next](@next)

--- a/Playground/RxSwiftExtPlayground.playground/contents.xcplayground
+++ b/Playground/RxSwiftExtPlayground.playground/contents.xcplayground
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='6.0' target-platform='ios' display-mode='rendered' last-migration='0900'>
+<playground version='6.0' target-platform='ios' display-mode='raw' last-migration='0900'>
     <pages>
         <page name='Index'/>
         <page name='apply'/>
@@ -22,5 +22,11 @@
         <page name='nwise'/>
         <page name='zipWith'/>
         <page name='ofType'/>
+        <page name='mapMany'/>
+        <page name='toSortedArray'/>
+        <page name='UIViewPropertyAnimator.animate'/>
+        <page name='UIViewPropertyAnimator.fractionComplete'/>
+        <page name='ifEmptySwitchToError'/>
+        <page name='withUnretained'/>
     </pages>
 </playground>

--- a/Readme.md
+++ b/Readme.md
@@ -79,6 +79,7 @@ These operators are much like the RxSwift & RxCocoa core operators, but provide 
 * [Observable.fromAsync](#fromasync)
 * [Observable.zip(with:)](#zipwith)
 * [withUnretained](#withunretained)
+* [ifEmpty(switchToSingleWithError:)](#ifempty)
 
 There are two more available operators for `materialize()`'d sequences:
 
@@ -561,6 +562,24 @@ next((Test Class, 5))
 next((Test Class, 8))
 next((Test Class, 13))
 completed
+```
+
+#### ifEmpty
+
+The `ifEmpty(switchToSingleWithError:)` operator transforms a Maybe into a Single in case the Maybe completes without success (ie if it is empty).
+In that case the Single will immediately emit the specified Error. It allows to consider the absence of value for the Maybe as an applicative error for instance.
+
+```swift
+Maybe<Bool>.create(subscribe: { (observer) -> Disposable in
+    observer(.completed)
+    return Disposables.create()
+})
+    .ifEmpty(switchToSingleWithError: SwitchToSingleWithError.completedError)
+    .subscribe(onSuccess: { (value) in
+        print ("The value will never be emitted since the Maybe is empty")
+    }, onError: { (error) in
+        print ("The completed event is transformed into this error: \(error)")
+    })
 ```
 
 Reactive Extensions details

--- a/RxSwiftExt.xcodeproj/project.pbxproj
+++ b/RxSwiftExt.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 
 /* Begin PBXBuildFile section */
 		188C6DA31C47B4240092101A /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 188C6DA21C47B4240092101A /* RxSwift.framework */; };
+		1A7865832155DA8A008AB973 /* ifEmptySwitchToError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A7865822155DA8A008AB973 /* ifEmptySwitchToError.swift */; };
+		1A7865852155DBAD008AB973 /* IfEmptySwitchToErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A7865842155DBAD008AB973 /* IfEmptySwitchToErrorTests.swift */; };
 		1A8741AC20745A91004BB762 /* UIViewPropertyAnimatorTests+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A8741AB20745A91004BB762 /* UIViewPropertyAnimatorTests+Rx.swift */; };
 		1AA8395B207451D6001C49ED /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1AA8395A207451D5001C49ED /* RxCocoa.framework */; };
 		3D11958B1FCAD9AE0095134B /* and.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DBDE5FB1FBBAE3900DF47F9 /* and.swift */; };
@@ -262,6 +264,8 @@
 /* Begin PBXFileReference section */
 		188C6D911C47B2B20092101A /* RxSwiftExt.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxSwiftExt.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		188C6DA21C47B4240092101A /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = Carthage/Build/iOS/RxSwift.framework; sourceTree = SOURCE_ROOT; };
+		1A7865822155DA8A008AB973 /* ifEmptySwitchToError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ifEmptySwitchToError.swift; sourceTree = "<group>"; };
+		1A7865842155DBAD008AB973 /* IfEmptySwitchToErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IfEmptySwitchToErrorTests.swift; sourceTree = "<group>"; };
 		1A8741AB20745A91004BB762 /* UIViewPropertyAnimatorTests+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewPropertyAnimatorTests+Rx.swift"; sourceTree = "<group>"; };
 		1AA8395A207451D5001C49ED /* RxCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxCocoa.framework; path = Carthage/Build/iOS/RxCocoa.framework; sourceTree = "<group>"; };
 		3D638DE71DC2B2D40089A590 /* RxSwiftExtTests-iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "RxSwiftExtTests-iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -500,6 +504,7 @@
 				C4D2153E20118A81009804AE /* ofType.swift */,
 				BF79DA09206C145D008AA708 /* withUnretained.swift */,
 				DC612871209E80810053CBB7 /* mapMany.swift */,
+				1A7865822155DA8A008AB973 /* ifEmptySwitchToError.swift */,
 			);
 			path = RxSwift;
 			sourceTree = "<group>";
@@ -535,6 +540,7 @@
 				538607CB1E6F367A000361DE /* WeakTests.swift */,
 				58C54E184069446EDEE748F9 /* ZipWithTest.swift */,
 				BF79DA0D206C185B008AA708 /* WithUnretainedTests.swift */,
+				1A7865842155DBAD008AB973 /* IfEmptySwitchToErrorTests.swift */,
 			);
 			name = RxSwift;
 			path = Tests/RxSwift;
@@ -868,13 +874,14 @@
 				"$(SRCROOT)/Carthage/Build/iOS/RxSwift.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/RxTest.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/RxCocoa.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/RxBlocking.framework",
 			);
 			name = "Copy carthage frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
+			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
 		};
 		87B3D2C1203EB014001327A4 /* Swiftlint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -929,7 +936,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "for framework in \"${PROJECT_DIR}\"/Carthage/Build/iOS/*.framework; do\nfile=`basename \"$framework\"`\nditto \"$framework\" \"${BUILT_PRODUCTS_DIR}/$file\"\ndone";
+			shellScript = "for framework in \"${PROJECT_DIR}\"/Carthage/Build/iOS/*.framework; do\nfile=`basename \"$framework\"`\nditto \"$framework\" \"${BUILT_PRODUCTS_DIR}/$file\"\ndone\n";
 		};
 		E36BDFBF1F38772F008C9D56 /* Copy carthage frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -981,6 +988,7 @@
 				538607AE1E6F334B000361DE /* ignore.swift in Sources */,
 				BF79DA0A206C145D008AA708 /* withUnretained.swift in Sources */,
 				BF515CE01F3F370600492640 /* curry.swift in Sources */,
+				1A7865832155DA8A008AB973 /* ifEmptySwitchToError.swift in Sources */,
 				5A1DDEBF1ED58F8600F2E4B1 /* pausableBuffered.swift in Sources */,
 				BF515CE21F3F371600492640 /* fromAsync.swift in Sources */,
 				DC612872209E80810053CBB7 /* mapMany.swift in Sources */,
@@ -1018,6 +1026,7 @@
 				538607E41E6F36A9000361DE /* IgnoreTests.swift in Sources */,
 				538607E31E6F36A9000361DE /* IgnoreErrorsTests.swift in Sources */,
 				53C79D621E6F5B3900CD9B6A /* NotTests+RxCocoa.swift in Sources */,
+				1A7865852155DBAD008AB973 /* IfEmptySwitchToErrorTests.swift in Sources */,
 				538607DD1E6F3692000361DE /* RepeatWithBehaviorTests.swift in Sources */,
 				538607EC1E6F36A9000361DE /* UnwrapTests.swift in Sources */,
 				538607DF1E6F36A9000361DE /* ApplyTests.swift in Sources */,

--- a/Source/RxSwift/ifEmptySwitchToError.swift
+++ b/Source/RxSwift/ifEmptySwitchToError.swift
@@ -1,0 +1,26 @@
+//
+//  ifEmptySwitchToError.swift
+//  RxSwiftExt
+//
+//  Created by Thibault Wittemberg on 21/09/18.
+//  Copyright © 2018 RxSwift Community. All rights reserved.
+//
+
+import RxSwift
+
+/// An extention to the Maybe trait that allows to trigger an Error in case of a "completed only" event (ie empty Maybe)
+extension PrimitiveSequenceType where TraitType == MaybeTrait {
+
+    /// If the Maybe triggers a Completed event without a Success first (ie empty Maybe), then it returns a Single that triggers the specified error
+    ///
+    /// - Parameter error: the Error the Single will trigger
+    /// - Returns: the Single that will trigger the Error
+    public func ifEmpty (switchToSingleWithError error: Error) -> Single<ElementType> {
+        let errorSingle = Single<ElementType>.create { (observer) -> Disposable in
+            observer(.error(error))
+            return Disposables.create()
+        }
+
+        return self.ifEmpty(switchTo: errorSingle)
+    }
+}

--- a/Tests/RxSwift/IfEmptySwitchToErrorTests.swift
+++ b/Tests/RxSwift/IfEmptySwitchToErrorTests.swift
@@ -1,0 +1,60 @@
+//
+//  IfEmptySwitchToErrorTests.swift
+//  RxSwiftExt
+//
+//  Created by Thibault Wittemberg on 21/09/18.
+//  Copyright © 2018 RxSwift Community. All rights reserved.
+//
+
+import XCTest
+import RxSwift
+import RxSwiftExt
+import RxBlocking
+
+enum SwitchToSingleWithError: Error {
+    case completedError
+}
+
+class IfEmptySwitchToErrorTests: XCTestCase {
+
+    func testMaybe_TriggerErrorWhenEmpty() {
+
+        // Given: a Maybe that only completes
+        let maybeThatCompletes = Maybe<Bool>.create { (observer) -> Disposable in
+            observer(.completed)
+            return Disposables.create()
+        }
+
+        do {
+            // When: observing that Maybe
+            _ = try maybeThatCompletes
+                .ifEmpty(switchToSingleWithError: SwitchToSingleWithError.completedError)
+                .toBlocking().single()
+        } catch {
+            // Then: the underlying single triggers the specified error
+            guard case SwitchToSingleWithError.completedError = error else {
+                XCTFail("Maybe has not triggered the right Error")
+                return
+            }
+        }
+    }
+
+    func testMaybe_TriggerSingleWhenNotEmpty() {
+
+        // Given: a Maybe that succeeds
+        let maybeThatSucceeds = Maybe<Bool>.create { (observer) -> Disposable in
+            observer(.success(true))
+            return Disposables.create()
+        }
+
+        // When: observing that Maybe
+        let value = try? maybeThatSucceeds
+            .ifEmpty(switchToSingleWithError: SwitchToSingleWithError.completedError)
+            .toBlocking().single()
+
+        // Then: the value is well triggered by the underlying Single, no error is thrown
+        XCTAssertNotNil(value)
+        XCTAssert(value!)
+    }
+
+}


### PR DESCRIPTION
This commit adds an extension the trait "Maybe" that transforms it into a Single
whenever it is empty (ie completes without succeed).

The difference with the already existing "ifEmpty" function is that the Single
will immediately emmit the specified Error.

It allows to consider the case when the Maybe is empty as an applicative error.