### PR TITLE
Handle thrown errors in filterMap and flatMapSync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 Changelog
 =========
 
-master
+3.4.0
 -----
 - Fix `withUnretained` so it allows proper destructuring
 - added `mapMany` operator
 - added `toSortedArray` operator
 - rolled `map(to:)` back to `mapTo(_:)` for `SharedSequenceConvertibleType`
+- added `filterMap` and `flatMapSync` overloads for throwable transforms
 
 3.3.0
 -----

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "ReactiveX/RxSwift" "4.2.0"
+github "ReactiveX/RxSwift" "4.3.1"

--- a/RxSwiftExt.podspec
+++ b/RxSwiftExt.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "RxSwiftExt"
-  s.version      = "3.3.0"
+  s.version      = "3.4.0"
   s.summary      = "RxSwift operators not found in the core distribtion"
   s.description  = <<-DESC
     A collection of operators for RxSwift adding commonly requested operations not found in the core distribution

--- a/Source/RxSwift/filterMap.swift
+++ b/Source/RxSwift/filterMap.swift
@@ -29,6 +29,17 @@ extension ObservableType {
         - returning `.ignore` will filter the value out of the returned Observable
         - returning `.map(newValue)` will propagate newValue through the returned Observable.
      */
+    public func filterMap<T>(_ transform: @escaping (E) -> FilterMap<T>) -> Observable<T> {
+        return flatMapSync { transform($0).asOperator }
+    }
+
+    /**
+     Filters or Maps values from the source.
+     - The returned Observable will error and complete with the source.
+     - `next` values will be output according to the `transform` callback result:
+     - returning `.ignore` will filter the value out of the returned Observable
+     - returning `.map(newValue)` will propagate newValue through the returned Observable.
+     */
     public func filterMap<T>(_ transform: @escaping (E) throws -> FilterMap<T>) -> Observable<T> {
         return flatMapSync { try transform($0).asOperator }
     }

--- a/Source/RxSwift/filterMap.swift
+++ b/Source/RxSwift/filterMap.swift
@@ -29,7 +29,7 @@ extension ObservableType {
         - returning `.ignore` will filter the value out of the returned Observable
         - returning `.map(newValue)` will propagate newValue through the returned Observable.
      */
-    public func filterMap<T>(_ transform: @escaping (E) -> FilterMap<T>) -> Observable<T> {
-        return flatMapSync { transform($0).asOperator }
+    public func filterMap<T>(_ transform: @escaping (E) throws -> FilterMap<T>) -> Observable<T> {
+        return flatMapSync { try transform($0).asOperator }
     }
 }

--- a/Source/RxSwift/flatMapSync.swift
+++ b/Source/RxSwift/flatMapSync.swift
@@ -58,6 +58,25 @@ extension ObservableType {
 
      see filterMap for an example of a custom operator
      */
+    public func flatMapSync<O: CustomOperator>(_ transform: @escaping (E) -> O) -> Observable<O.Result> {
+        return Observable.create { observer in
+            return self.subscribe { event in
+                switch event {
+                case .next(let element): transform(element).apply { observer.onNext($0) }
+                case .completed: observer.onCompleted()
+                case .error(let error): observer.onError(error)
+                }
+            }
+        }
+    }
+
+    /**
+     FlatMaps values from a stream synchronously using CustomOperator type.
+     - The returned Observable will error and complete with the source.
+     - `next` values will be transformed by according to the CustomOperator application rules.
+
+     see filterMap for an example of a custom operator
+     */
     public func flatMapSync<O: CustomOperator>(_ transform: @escaping (E) throws -> O) -> Observable<O.Result> {
         return Observable.create { observer in
             return self.subscribe { event in

--- a/Source/RxSwift/flatMapSync.swift
+++ b/Source/RxSwift/flatMapSync.swift
@@ -58,13 +58,20 @@ extension ObservableType {
 
      see filterMap for an example of a custom operator
      */
-    public func flatMapSync<O: CustomOperator>(_ transform: @escaping (E) -> O) -> Observable<O.Result> {
+    public func flatMapSync<O: CustomOperator>(_ transform: @escaping (E) throws -> O) -> Observable<O.Result> {
         return Observable.create { observer in
             return self.subscribe { event in
                 switch event {
-                case .next(let element): transform(element).apply { observer.onNext($0) }
-                case .completed: observer.onCompleted()
-                case .error(let error): observer.onError(error)
+                case .next(let element):
+                    do {
+                        try transform(element).apply { observer.onNext($0) }
+                    } catch {
+                        observer.onError(error)
+                    }
+                case .completed:
+                    observer.onCompleted()
+                case .error(let error):
+                    observer.onError(error)
                 }
             }
         }


### PR DESCRIPTION
RxSwift's map, filter, and flatMap all catch (and transmit) errors via `throw`, so I have added this functionality to flatMapSync and filterMap.