### PR TITLE
Partition operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 master
 -----
 
-Nothing yet!
+- added `partition(_:)` operator
 
 3.4.0
 -----

--- a/Playground/RxSwiftExtPlayground.playground/Pages/Index.xcplaygroundpage/Contents.swift
+++ b/Playground/RxSwiftExtPlayground.playground/Pages/Index.xcplaygroundpage/Contents.swift
@@ -44,6 +44,7 @@
  - [ofType()](ofType) operator, filters the elements of an observable sequence, if that is an instance of the supplied type.
  - [toSortedArray()](mapMany) operator, converts an Observable into another Observable that emits the whole sequence as a single array sorted using the provided closure and then terminates.
  - [count(predicate)](count) operator, counts the number of items emitted by an Observable. If predicate exists, then counts the number of items satisfying it.
+ - [partition](partition) operator, partition a stream into two separate streams of elements that match, and don't match, the provided predicate.
  - **UIViewPropertyAnimator** [animate()](UIViewPropertyAnimator.animate) operator, returns a Completable that completes as soon as the animation ends.
  - **UIViewPropertyAnimator** [fractionComplete](UIViewPropertyAnimator.fractionComplete) binder, provides a reactive way to bind to `UIViewPropertyAnimator.fractionComplete`.
 */

--- a/Playground/RxSwiftExtPlayground.playground/Pages/partition.xcplaygroundpage/Contents.swift
+++ b/Playground/RxSwiftExtPlayground.playground/Pages/partition.xcplaygroundpage/Contents.swift
@@ -1,0 +1,25 @@
+/*:
+ > # IMPORTANT: To use `RxSwiftExtPlayground.playground`, please:
+ 
+ 1. Make sure you have [Carthage](https://github.com/Carthage/Carthage) installed
+ 1. Fetch Carthage dependencies from shell: `carthage bootstrap --platform ios`
+ 1. Build scheme `RxSwiftExtPlayground` scheme for a simulator target
+ 1. Choose `View > Show Debug Area`
+ */
+
+//: [Previous](@previous)
+
+import RxSwift
+import RxSwiftExt
+
+example("partition") {
+    let numbers = Observable
+        .of(1, 2, 3, 5, 8, 13, 18, 21, 23)
+
+    let (evens, odds) = numbers.partition { $0 % 2 == 0 }
+
+    _ = evens.debug("even").subscribe()
+    _ = odds.debug("odds").subscribe()
+}
+//: [Next](@next)
+

--- a/Readme.md
+++ b/Readme.md
@@ -81,6 +81,7 @@ These operators are much like the RxSwift & RxCocoa core operators, but provide 
 * [Observable.zip(with:)](#zipwith)
 * [withUnretained](#withunretained)
 * [count](#count)
+* [partition](#partition)
 
 There are two more available operators for `materialize()`'d sequences:
 
@@ -596,6 +597,20 @@ Observable.from([1, 2, 3, 4, 5, 6])
 ```
 next(3)
 completed
+```
+
+#### partition
+
+Partition a stream into two separate streams of elements that match, and don't match, the provided predicate.
+
+```swift
+let numbers = Observable
+        .of(1, 2, 3, 4, 5, 6)
+
+    let (evens, odds) = numbers.partition { $0 % 2 == 0 }
+
+    _ = evens.debug("even").subscribe() // emits 2, 4, 6
+    _ = odds.debug("odds").subscribe() // emits 1, 3, 5
 ```
 
 Reactive Extensions details

--- a/RxSwiftExt.xcodeproj/project.pbxproj
+++ b/RxSwiftExt.xcodeproj/project.pbxproj
@@ -565,6 +565,7 @@
 				538607CB1E6F367A000361DE /* WeakTests.swift */,
 				58C54E184069446EDEE748F9 /* ZipWithTest.swift */,
 				BF79DA0D206C185B008AA708 /* WithUnretainedTests.swift */,
+				A23E148E21A9F10D00CD5B2F /* PartitionTests.swift */,
 			);
 			name = RxSwift;
 			path = Tests/RxSwift;
@@ -1030,6 +1031,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				538607E01E6F36A9000361DE /* CascadeTests.swift in Sources */,
+				A23E148F21A9F10D00CD5B2F /* PartitionTests.swift in Sources */,
 				53F336EA1E70D59000D35D38 /* DistinctTests+RxCocoa.swift in Sources */,
 				98309EB41EDF167300BD07D9 /* FilterMapTests.swift in Sources */,
 				B69B454E2190C3CC00F30418 /* CountTests.swift in Sources */,
@@ -1132,6 +1134,7 @@
 				62512C9E1F0EB1850083A89F /* PausableBufferedTests.swift in Sources */,
 				62512CA01F0EB1850083A89F /* RetryWithBehaviorTests.swift in Sources */,
 				C4D2154320118FB9009804AE /* Observable+OfTypeTests.swift in Sources */,
+				A23E149021A9F10D00CD5B2F /* PartitionTests.swift in Sources */,
 				780CB21E20A0EE8300FD3F39 /* MapManyTests.swift in Sources */,
 				62512C911F0EB17F0083A89F /* NotTests+RxCocoa.swift in Sources */,
 				62512C9A1F0EB1850083A89F /* Materialized+elementsTests.swift in Sources */,
@@ -1213,6 +1216,7 @@
 				E39C420E1F18B13E007F2ACD /* RetryWithBehaviorTests.swift in Sources */,
 				E39C42061F18B13E007F2ACD /* IgnoreWhenTests.swift in Sources */,
 				C4D2154420118FBA009804AE /* Observable+OfTypeTests.swift in Sources */,
+				A23E149121A9F10D00CD5B2F /* PartitionTests.swift in Sources */,
 				780CB21F20A0EE8300FD3F39 /* MapManyTests.swift in Sources */,
 				E39C420C1F18B13E007F2ACD /* PausableBufferedTests.swift in Sources */,
 				E39C42041F18B13E007F2ACD /* IgnoreErrorsTests.swift in Sources */,

--- a/RxSwiftExt.xcodeproj/project.pbxproj
+++ b/RxSwiftExt.xcodeproj/project.pbxproj
@@ -159,6 +159,9 @@
 		A23E148F21A9F10D00CD5B2F /* PartitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23E148E21A9F10D00CD5B2F /* PartitionTests.swift */; };
 		A23E149021A9F10D00CD5B2F /* PartitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23E148E21A9F10D00CD5B2F /* PartitionTests.swift */; };
 		A23E149121A9F10D00CD5B2F /* PartitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23E148E21A9F10D00CD5B2F /* PartitionTests.swift */; };
+		A23E149321A9F73500CD5B2F /* PartitionTests+RxCocoa.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23E149221A9F73500CD5B2F /* PartitionTests+RxCocoa.swift */; };
+		A23E149421A9F73500CD5B2F /* PartitionTests+RxCocoa.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23E149221A9F73500CD5B2F /* PartitionTests+RxCocoa.swift */; };
+		A23E149521A9F73500CD5B2F /* PartitionTests+RxCocoa.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23E149221A9F73500CD5B2F /* PartitionTests+RxCocoa.swift */; };
 		B69B45492190C27D00F30418 /* count.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69B45482190C27D00F30418 /* count.swift */; };
 		B69B454A2190C3AE00F30418 /* count.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69B45482190C27D00F30418 /* count.swift */; };
 		B69B454B2190C3AF00F30418 /* count.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69B45482190C27D00F30418 /* count.swift */; };
@@ -348,6 +351,7 @@
 		A23E148621A9EFC000CD5B2F /* partition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = partition.swift; sourceTree = "<group>"; };
 		A23E148A21A9F03600CD5B2F /* partition+RxCocoa.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "partition+RxCocoa.swift"; sourceTree = "<group>"; };
 		A23E148E21A9F10D00CD5B2F /* PartitionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PartitionTests.swift; sourceTree = "<group>"; };
+		A23E149221A9F73500CD5B2F /* PartitionTests+RxCocoa.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PartitionTests+RxCocoa.swift"; sourceTree = "<group>"; };
 		B69B45482190C27D00F30418 /* count.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = count.swift; sourceTree = "<group>"; };
 		B69B454C2190C3BC00F30418 /* CountTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountTests.swift; sourceTree = "<group>"; };
 		BF515CDF1F3F370600492640 /* curry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = curry.swift; path = Source/Tools/curry.swift; sourceTree = SOURCE_ROOT; };
@@ -491,6 +495,7 @@
 				53C79D5F1E6F5AAB00CD9B6A /* NotTests+RxCocoa.swift */,
 				1A8741AB20745A91004BB762 /* UIViewPropertyAnimatorTests+Rx.swift */,
 				1958B5F521676ECB00CAF1D3 /* unrwapTests+SharedSequence.swift */,
+				A23E149221A9F73500CD5B2F /* PartitionTests+RxCocoa.swift */,
 			);
 			name = RxCocoa;
 			path = Tests/RxCocoa;
@@ -1044,6 +1049,7 @@
 				538607E21E6F36A9000361DE /* DistinctTests.swift in Sources */,
 				538607EA1E6F36A9000361DE /* PausableTests.swift in Sources */,
 				538607E91E6F36A9000361DE /* OnceTests.swift in Sources */,
+				A23E149321A9F73500CD5B2F /* PartitionTests+RxCocoa.swift in Sources */,
 				BF79DA0E206C185B008AA708 /* WithUnretainedTests.swift in Sources */,
 				538607EE1E6F36A9000361DE /* WeakTests.swift in Sources */,
 				780CB21920A0ED3B00FD3F39 /* ToSortedArrayTests.swift in Sources */,
@@ -1120,6 +1126,7 @@
 				62512C901F0EB17D0083A89F /* MapToTests+RxCocoa.swift in Sources */,
 				62512C961F0EB1850083A89F /* IgnoreErrorsTests.swift in Sources */,
 				BF515CE61F3F3AF500492640 /* FromAsyncTests.swift in Sources */,
+				A23E149421A9F73500CD5B2F /* PartitionTests+RxCocoa.swift in Sources */,
 				62512CA41F0EB1850083A89F /* FilterMapTests.swift in Sources */,
 				B69B454F2190C3CC00F30418 /* CountTests.swift in Sources */,
 				D7C72A3F1FDC5C5D00EAAAAB /* NwiseTests.swift in Sources */,
@@ -1202,6 +1209,7 @@
 				E39C420F1F18B13E007F2ACD /* UnwrapTests.swift in Sources */,
 				E39C42121F18B13E007F2ACD /* FilterMapTests.swift in Sources */,
 				BF515CE71F3F3AF500492640 /* FromAsyncTests.swift in Sources */,
+				A23E149521A9F73500CD5B2F /* PartitionTests+RxCocoa.swift in Sources */,
 				E39C41FF1F18B13A007F2ACD /* NotTests+RxCocoa.swift in Sources */,
 				B69B45502190C3CD00F30418 /* CountTests.swift in Sources */,
 				D7C72A401FDC5C5D00EAAAAB /* NwiseTests.swift in Sources */,

--- a/RxSwiftExt.xcodeproj/project.pbxproj
+++ b/RxSwiftExt.xcodeproj/project.pbxproj
@@ -153,6 +153,9 @@
 		A23E148721A9EFC000CD5B2F /* partition.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23E148621A9EFC000CD5B2F /* partition.swift */; };
 		A23E148821A9EFC000CD5B2F /* partition.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23E148621A9EFC000CD5B2F /* partition.swift */; };
 		A23E148921A9EFC000CD5B2F /* partition.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23E148621A9EFC000CD5B2F /* partition.swift */; };
+		A23E148B21A9F03600CD5B2F /* partition+RxCocoa.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23E148A21A9F03600CD5B2F /* partition+RxCocoa.swift */; };
+		A23E148C21A9F03600CD5B2F /* partition+RxCocoa.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23E148A21A9F03600CD5B2F /* partition+RxCocoa.swift */; };
+		A23E148D21A9F03600CD5B2F /* partition+RxCocoa.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23E148A21A9F03600CD5B2F /* partition+RxCocoa.swift */; };
 		A23E148F21A9F10D00CD5B2F /* PartitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23E148E21A9F10D00CD5B2F /* PartitionTests.swift */; };
 		A23E149021A9F10D00CD5B2F /* PartitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23E148E21A9F10D00CD5B2F /* PartitionTests.swift */; };
 		A23E149121A9F10D00CD5B2F /* PartitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23E148E21A9F10D00CD5B2F /* PartitionTests.swift */; };
@@ -343,6 +346,7 @@
 		98309EB21EDF161700BD07D9 /* FilterMapTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FilterMapTests.swift; sourceTree = "<group>"; };
 		9DAB77851D67639C007E85BC /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Source/Info.plist; sourceTree = SOURCE_ROOT; };
 		A23E148621A9EFC000CD5B2F /* partition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = partition.swift; sourceTree = "<group>"; };
+		A23E148A21A9F03600CD5B2F /* partition+RxCocoa.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "partition+RxCocoa.swift"; sourceTree = "<group>"; };
 		A23E148E21A9F10D00CD5B2F /* PartitionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PartitionTests.swift; sourceTree = "<group>"; };
 		B69B45482190C27D00F30418 /* count.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = count.swift; sourceTree = "<group>"; };
 		B69B454C2190C3BC00F30418 /* CountTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountTests.swift; sourceTree = "<group>"; };
@@ -474,6 +478,7 @@
 				538607EF1E6F589E000361DE /* not+RxCocoa.swift */,
 				4A73956B206D501300E2BE2D /* UIViewPropertyAnimator+Rx.swift */,
 				1958B5F0216768D900CAF1D3 /* unwrap+SharedSequence.swift */,
+				A23E148A21A9F03600CD5B2F /* partition+RxCocoa.swift */,
 			);
 			path = RxCocoa;
 			sourceTree = "<group>";
@@ -1013,6 +1018,7 @@
 				BF515CE21F3F371600492640 /* fromAsync.swift in Sources */,
 				DC612872209E80810053CBB7 /* mapMany.swift in Sources */,
 				5386076F1E6F1C0A000361DE /* mapTo+RxCocoa.swift in Sources */,
+				A23E148B21A9F03600CD5B2F /* partition+RxCocoa.swift in Sources */,
 				538607B71E6F334B000361DE /* repeatWithBehavior.swift in Sources */,
 				538607AC1E6F334B000361DE /* catchErrorJustComplete.swift in Sources */,
 				58C5450451345D65DF48F6C5 /* zipWith.swift in Sources */,
@@ -1091,6 +1097,7 @@
 				DC612873209E80810053CBB7 /* mapMany.swift in Sources */,
 				BF79DA0B206C145D008AA708 /* withUnretained.swift in Sources */,
 				A23E148821A9EFC000CD5B2F /* partition.swift in Sources */,
+				A23E148C21A9F03600CD5B2F /* partition+RxCocoa.swift in Sources */,
 				BF515CE81F3F3B0000492640 /* fromAsync.swift in Sources */,
 				BF515CEA1F3F3B0300492640 /* curry.swift in Sources */,
 				62512C691F0EAF850083A89F /* not+RxCocoa.swift in Sources */,
@@ -1171,6 +1178,7 @@
 				DC612874209E80810053CBB7 /* mapMany.swift in Sources */,
 				BF79DA0C206C145D008AA708 /* withUnretained.swift in Sources */,
 				A23E148921A9EFC000CD5B2F /* partition.swift in Sources */,
+				A23E148D21A9F03600CD5B2F /* partition+RxCocoa.swift in Sources */,
 				BF515CE91F3F3B0100492640 /* fromAsync.swift in Sources */,
 				BF515CEB1F3F3B0300492640 /* curry.swift in Sources */,
 				E39C41DA1F18B086007F2ACD /* not+RxCocoa.swift in Sources */,

--- a/RxSwiftExt.xcodeproj/project.pbxproj
+++ b/RxSwiftExt.xcodeproj/project.pbxproj
@@ -150,6 +150,12 @@
 		98309EAF1EDF14AC00BD07D9 /* flatMapSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98309EAE1EDF14AC00BD07D9 /* flatMapSync.swift */; };
 		98309EB11EDF159500BD07D9 /* filterMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98309EB01EDF159500BD07D9 /* filterMap.swift */; };
 		98309EB41EDF167300BD07D9 /* FilterMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98309EB21EDF161700BD07D9 /* FilterMapTests.swift */; };
+		A23E148721A9EFC000CD5B2F /* partition.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23E148621A9EFC000CD5B2F /* partition.swift */; };
+		A23E148821A9EFC000CD5B2F /* partition.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23E148621A9EFC000CD5B2F /* partition.swift */; };
+		A23E148921A9EFC000CD5B2F /* partition.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23E148621A9EFC000CD5B2F /* partition.swift */; };
+		A23E148F21A9F10D00CD5B2F /* PartitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23E148E21A9F10D00CD5B2F /* PartitionTests.swift */; };
+		A23E149021A9F10D00CD5B2F /* PartitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23E148E21A9F10D00CD5B2F /* PartitionTests.swift */; };
+		A23E149121A9F10D00CD5B2F /* PartitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23E148E21A9F10D00CD5B2F /* PartitionTests.swift */; };
 		B69B45492190C27D00F30418 /* count.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69B45482190C27D00F30418 /* count.swift */; };
 		B69B454A2190C3AE00F30418 /* count.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69B45482190C27D00F30418 /* count.swift */; };
 		B69B454B2190C3AF00F30418 /* count.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69B45482190C27D00F30418 /* count.swift */; };
@@ -336,6 +342,8 @@
 		98309EB01EDF159500BD07D9 /* filterMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = filterMap.swift; path = Source/RxSwift/filterMap.swift; sourceTree = SOURCE_ROOT; };
 		98309EB21EDF161700BD07D9 /* FilterMapTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FilterMapTests.swift; sourceTree = "<group>"; };
 		9DAB77851D67639C007E85BC /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Source/Info.plist; sourceTree = SOURCE_ROOT; };
+		A23E148621A9EFC000CD5B2F /* partition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = partition.swift; sourceTree = "<group>"; };
+		A23E148E21A9F10D00CD5B2F /* PartitionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PartitionTests.swift; sourceTree = "<group>"; };
 		B69B45482190C27D00F30418 /* count.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = count.swift; sourceTree = "<group>"; };
 		B69B454C2190C3BC00F30418 /* CountTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountTests.swift; sourceTree = "<group>"; };
 		BF515CDF1F3F370600492640 /* curry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = curry.swift; path = Source/Tools/curry.swift; sourceTree = SOURCE_ROOT; };
@@ -515,6 +523,7 @@
 				C4D2153E20118A81009804AE /* ofType.swift */,
 				BF79DA09206C145D008AA708 /* withUnretained.swift */,
 				DC612871209E80810053CBB7 /* mapMany.swift */,
+				A23E148621A9EFC000CD5B2F /* partition.swift */,
 			);
 			path = RxSwift;
 			sourceTree = "<group>";
@@ -995,6 +1004,7 @@
 				780CB21520A0ED1C00FD3F39 /* toSortedArray.swift in Sources */,
 				98309EB11EDF159500BD07D9 /* filterMap.swift in Sources */,
 				53F336E81E70CBF700D35D38 /* distinct+RxCocoa.swift in Sources */,
+				A23E148721A9EFC000CD5B2F /* partition.swift in Sources */,
 				538607AE1E6F334B000361DE /* ignore.swift in Sources */,
 				BF79DA0A206C145D008AA708 /* withUnretained.swift in Sources */,
 				BF515CE01F3F370600492640 /* curry.swift in Sources */,
@@ -1080,6 +1090,7 @@
 				62512C791F0EAF950083A89F /* retryWithBehavior.swift in Sources */,
 				DC612873209E80810053CBB7 /* mapMany.swift in Sources */,
 				BF79DA0B206C145D008AA708 /* withUnretained.swift in Sources */,
+				A23E148821A9EFC000CD5B2F /* partition.swift in Sources */,
 				BF515CE81F3F3B0000492640 /* fromAsync.swift in Sources */,
 				BF515CEA1F3F3B0300492640 /* curry.swift in Sources */,
 				62512C691F0EAF850083A89F /* not+RxCocoa.swift in Sources */,
@@ -1159,6 +1170,7 @@
 				E39C41EA1F18B08A007F2ACD /* retryWithBehavior.swift in Sources */,
 				DC612874209E80810053CBB7 /* mapMany.swift in Sources */,
 				BF79DA0C206C145D008AA708 /* withUnretained.swift in Sources */,
+				A23E148921A9EFC000CD5B2F /* partition.swift in Sources */,
 				BF515CE91F3F3B0100492640 /* fromAsync.swift in Sources */,
 				BF515CEB1F3F3B0300492640 /* curry.swift in Sources */,
 				E39C41DA1F18B086007F2ACD /* not+RxCocoa.swift in Sources */,

--- a/Source/RxCocoa/partition+RxCocoa.swift
+++ b/Source/RxCocoa/partition+RxCocoa.swift
@@ -1,0 +1,27 @@
+//
+//  partition+RxCocoa.swift
+//  RxSwiftExt
+//
+//  Created by Shai Mishali on 24/11/2018.
+//  Copyright © 2018 RxSwiftCommunity. All rights reserved.
+//
+
+import RxSwift
+import RxCocoa
+
+public extension SharedSequence {
+    /**
+     Partition a stream into two separate streams of elements that match, and don't match, the provided predicate.
+
+     - parameter predicate: A predicate used to filter matching and non-matching elements.
+
+     - returns: A tuple of two streams of elements that match, and don't match, the provided predicate.
+     */
+    func partition(_ predicate: @escaping (E) -> Bool) -> (matches: SharedSequence<S, E>,
+                                                           nonMatches: SharedSequence<S, E>) {
+        let hits = self.filter(predicate)
+        let misses = self.filter { !predicate($0) }
+
+        return (hits, misses)
+    }
+}

--- a/Source/RxSwift/partition.swift
+++ b/Source/RxSwift/partition.swift
@@ -1,0 +1,27 @@
+//
+//  partition.swift
+//  RxSwiftExt
+//
+//  Created by Shai Mishali on 24/11/2018.
+//  Copyright © 2018 RxSwiftCommunity. All rights reserved.
+//
+
+import RxSwift
+
+public extension ObservableType {
+    /**
+     Partition a stream into two separate streams of elements that match, and don't match, the provided predicate.
+
+     - parameter predicate: A predicate used to filter matching and non-matching elements.
+
+     - returns: A tuple of two streams of elements that match, and don't match, the provided predicate.
+    */
+    func partition(_ predicate: @escaping (E) throws -> Bool) -> (matches: Observable<E>, nonMatches: Observable<E>) {
+        let stream = self.share()
+        let hits = stream.filter(predicate)
+        let misses = stream.filter {
+            return !(try predicate($0))
+        }
+        return (hits, misses)
+    }
+}

--- a/Tests/RxCocoa/PartitionTests+RxCocoa.swift
+++ b/Tests/RxCocoa/PartitionTests+RxCocoa.swift
@@ -1,0 +1,91 @@
+//
+//  PartitionTests+RxCocoa.swift
+//  RxSwiftExt
+//
+//  Created by Shai Mishali on 24/11/2018.
+//  Copyright © 2018 RxSwiftCommunity. All rights reserved.
+//
+
+import Foundation
+import RxSwift
+import RxCocoa
+import RxTest
+import XCTest
+import RxSwiftExt
+
+class PartitionSharedStrategyTests: XCTestCase {
+    private var scheduler = TestScheduler(initialClock: 0)
+    private var stream: Driver<Int>!
+
+    override func setUp() {
+        super.setUp()
+        scheduler = TestScheduler(initialClock: 0)
+        let events = (0...10).map { i -> Recorded<Event<Int>> in
+            return .next(i * 10, i)
+        } + [.completed(100)]
+
+        stream = scheduler
+                    .createHotObservable(events)
+                    .asDriver(onErrorDriveWith: .never())
+    }
+
+    func testPartitionBothMatch() {
+        let (evens, odds) = stream.partition { $0 % 2 == 0 }
+
+        let evensObserver = scheduler.createObserver(Int.self)
+        _ = evens.drive(evensObserver)
+
+        let oddsObserver = scheduler.createObserver(Int.self)
+        _ = odds.drive(oddsObserver)
+
+        scheduler.start()
+
+        XCTAssertEqual(oddsObserver.events, Recorded.events([
+            .next(10, 1),
+            .next(30, 3),
+            .next(50, 5),
+            .next(70, 7),
+            .next(90, 9),
+            .completed(100)
+        ]))
+
+        XCTAssertEqual(evensObserver.events, Recorded.events([
+            .next(0, 0),
+            .next(20, 2),
+            .next(40, 4),
+            .next(60, 6),
+            .next(80, 8),
+            .next(100, 10),
+            .completed(100)
+        ]))
+    }
+
+    func testPartitionOneSideMatch() {
+        let (all, none) = stream.partition { $0 <= 10 }
+
+        let allObserver = scheduler.createObserver(Int.self)
+        _ = all.drive(allObserver)
+
+        let noneObserver = scheduler.createObserver(Int.self)
+        _ = none.drive(noneObserver)
+
+        scheduler.start()
+
+        XCTAssertEqual(allObserver.events, Recorded.events([
+            .next(0, 0),
+            .next(10, 1),
+            .next(20, 2),
+            .next(30, 3),
+            .next(40, 4),
+            .next(50, 5),
+            .next(60, 6),
+            .next(70, 7),
+            .next(80, 8),
+            .next(90, 9),
+            .next(100, 10),
+            .completed(100)
+        ]))
+
+        XCTAssertEqual(noneObserver.events, [.completed(100)])
+    }
+}

--- a/Tests/RxSwift/PartitionTests.swift
+++ b/Tests/RxSwift/PartitionTests.swift
@@ -1,0 +1,88 @@
+//
+//  PartitionTests.swift
+//  RxSwiftExt
+//
+//  Created by Shai Mishali on 24/11/2018.
+//  Copyright © 2018 RxSwiftCommunity. All rights reserved.
+//
+
+import Foundation
+import RxSwift
+import RxTest
+import XCTest
+import RxSwiftExt
+
+class PartitionTests: XCTestCase {
+    private var scheduler = TestScheduler(initialClock: 0)
+    private var stream: TestableObservable<Int>!
+
+    override func setUp() {
+        super.setUp()
+        scheduler = TestScheduler(initialClock: 0)
+        let events = (0...10).map { i -> Recorded<Event<Int>> in
+            return .next(i * 10, i)
+        } + [.completed(100)]
+
+        stream = scheduler.createHotObservable(events)
+    }
+
+    func testPartitionBothMatch() {
+        let (evens, odds) = stream.partition { $0 % 2 == 0 }
+
+        let evensObserver = scheduler.createObserver(Int.self)
+        _ = evens.bind(to: evensObserver)
+
+        let oddsObserver = scheduler.createObserver(Int.self)
+        _ = odds.bind(to: oddsObserver)
+
+        scheduler.start()
+
+        XCTAssertEqual(oddsObserver.events, Recorded.events([
+            .next(10, 1),
+            .next(30, 3),
+            .next(50, 5),
+            .next(70, 7),
+            .next(90, 9),
+            .completed(100)
+        ]))
+
+        XCTAssertEqual(evensObserver.events, Recorded.events([
+            .next(0, 0),
+            .next(20, 2),
+            .next(40, 4),
+            .next(60, 6),
+            .next(80, 8),
+            .next(100, 10),
+            .completed(100)
+        ]))
+    }
+
+    func testPartitionOneSideMatch() {
+        let (all, none) = stream.partition { $0 <= 10 }
+
+        let allObserver = scheduler.createObserver(Int.self)
+        _ = all.bind(to: allObserver)
+
+        let noneObserver = scheduler.createObserver(Int.self)
+        _ = none.bind(to: noneObserver)
+
+        scheduler.start()
+
+        XCTAssertEqual(allObserver.events, Recorded.events([
+            .next(0, 0),
+            .next(10, 1),
+            .next(20, 2),
+            .next(30, 3),
+            .next(40, 4),
+            .next(50, 5),
+            .next(60, 6),
+            .next(70, 7),
+            .next(80, 8),
+            .next(90, 9),
+            .next(100, 10),
+            .completed(100)
+        ]))
+
+        XCTAssertEqual(noneObserver.events, [.completed(100)])
+    }
+}


### PR DESCRIPTION
This is a new operator we've been using in our codebase that seems generic and useful, and I think would be a good fit here :) 

Partition would split a stream into two streams - one with elements matching the predicate, and one with elements not with matching the predicate.

The name partition came from Haskell: http://hackage.haskell.org/package/base-4.12.0.0/docs/Data-List.html#v:partition

This lets you do things like 

```swift
let numbers = Observable.of(1, 2, 3, 4, 5, 6)

let (evens, odds) = numbers.partition { $0 % 2 == 0 }

_ = evens.debug("even").subscribe() // emits 2, 4, 6
_ = odds.debug("odds").subscribe() // emits 1, 3, 5

// Another example:

let currentState: Observable<State> = ...

let (isLoading, isIdle) = currentState.partition { $0 == .loading }
```

Would appreciate your opinion :)