### PR TITLE
[WIP] overridingScan operator

### DIFF
--- a/RxSwiftExt.xcodeproj/project.pbxproj
+++ b/RxSwiftExt.xcodeproj/project.pbxproj
@@ -171,6 +171,12 @@
 		C4D2154420118FBA009804AE /* Observable+OfTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D2154020118F8B009804AE /* Observable+OfTypeTests.swift */; };
 		C4D2154520118FC1009804AE /* ofType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D2153E20118A81009804AE /* ofType.swift */; };
 		C4D2154620118FC1009804AE /* ofType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D2153E20118A81009804AE /* ofType.swift */; };
+		C51708D32226F3DD0058EF47 /* overridingScan.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51708D22226F3DD0058EF47 /* overridingScan.swift */; };
+		C51708D42226F3DD0058EF47 /* overridingScan.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51708D22226F3DD0058EF47 /* overridingScan.swift */; };
+		C51708D52226F3DD0058EF47 /* overridingScan.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51708D22226F3DD0058EF47 /* overridingScan.swift */; };
+		C51708D72226F6B00058EF47 /* OverridingScanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51708D62226F6B00058EF47 /* OverridingScanTests.swift */; };
+		C51708D82226F6B00058EF47 /* OverridingScanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51708D62226F6B00058EF47 /* OverridingScanTests.swift */; };
+		C51708D92226F6B00058EF47 /* OverridingScanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51708D62226F6B00058EF47 /* OverridingScanTests.swift */; };
 		D7C72A3E1FDC5C5D00EAAAAB /* NwiseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C72A3D1FDC5C5D00EAAAAB /* NwiseTests.swift */; };
 		D7C72A3F1FDC5C5D00EAAAAB /* NwiseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C72A3D1FDC5C5D00EAAAAB /* NwiseTests.swift */; };
 		D7C72A401FDC5C5D00EAAAAB /* NwiseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C72A3D1FDC5C5D00EAAAAB /* NwiseTests.swift */; };
@@ -337,6 +343,8 @@
 		BF79DA0D206C185B008AA708 /* WithUnretainedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithUnretainedTests.swift; sourceTree = "<group>"; };
 		C4D2153E20118A81009804AE /* ofType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ofType.swift; sourceTree = "<group>"; };
 		C4D2154020118F8B009804AE /* Observable+OfTypeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Observable+OfTypeTests.swift"; sourceTree = "<group>"; };
+		C51708D22226F3DD0058EF47 /* overridingScan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = overridingScan.swift; sourceTree = "<group>"; };
+		C51708D62226F6B00058EF47 /* OverridingScanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverridingScanTests.swift; sourceTree = "<group>"; };
 		D7C72A3D1FDC5C5D00EAAAAB /* NwiseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NwiseTests.swift; sourceTree = "<group>"; };
 		D7C72A411FDC5D8F00EAAAAB /* nwise.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = nwise.swift; path = Source/RxSwift/nwise.swift; sourceTree = SOURCE_ROOT; };
 		DC612871209E80810053CBB7 /* mapMany.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = mapMany.swift; sourceTree = "<group>"; };
@@ -506,6 +514,7 @@
 				C4D2153E20118A81009804AE /* ofType.swift */,
 				BF79DA09206C145D008AA708 /* withUnretained.swift */,
 				DC612871209E80810053CBB7 /* mapMany.swift */,
+				C51708D22226F3DD0058EF47 /* overridingScan.swift */,
 			);
 			path = RxSwift;
 			sourceTree = "<group>";
@@ -541,6 +550,7 @@
 				538607CB1E6F367A000361DE /* WeakTests.swift */,
 				58C54E184069446EDEE748F9 /* ZipWithTest.swift */,
 				BF79DA0D206C185B008AA708 /* WithUnretainedTests.swift */,
+				C51708D62226F6B00058EF47 /* OverridingScanTests.swift */,
 			);
 			name = RxSwift;
 			path = Tests/RxSwift;
@@ -977,6 +987,7 @@
 				3DBDE5FC1FBBAE3A00DF47F9 /* and.swift in Sources */,
 				8CF5F8B3202D6C5F00C1BA97 /* mapAt.swift in Sources */,
 				538607B31E6F334B000361DE /* not.swift in Sources */,
+				C51708D32226F3DD0058EF47 /* overridingScan.swift in Sources */,
 				538607AD1E6F334B000361DE /* distinct.swift in Sources */,
 				D7C72A421FDC5D8F00EAAAAB /* nwise.swift in Sources */,
 				538607B61E6F334B000361DE /* pausable.swift in Sources */,
@@ -1029,6 +1040,7 @@
 				538607DD1E6F3692000361DE /* RepeatWithBehaviorTests.swift in Sources */,
 				538607EC1E6F36A9000361DE /* UnwrapTests.swift in Sources */,
 				538607DF1E6F36A9000361DE /* ApplyTests.swift in Sources */,
+				C51708D72226F6B00058EF47 /* OverridingScanTests.swift in Sources */,
 				538607731E6F1D51000361DE /* MapToTests+RxCocoa.swift in Sources */,
 				538607E61E6F36A9000361DE /* MapToTests.swift in Sources */,
 				5A5FCE411ED5AEC60052A9B5 /* PausableBufferedTests.swift in Sources */,
@@ -1055,6 +1067,7 @@
 				62512C761F0EAF950083A89F /* pausable.swift in Sources */,
 				62512C721F0EAF950083A89F /* materialized+elements.swift in Sources */,
 				C4D2154520118FC1009804AE /* ofType.swift in Sources */,
+				C51708D42226F3DD0058EF47 /* overridingScan.swift in Sources */,
 				62512C6E1F0EAF950083A89F /* ignore.swift in Sources */,
 				3D11958B1FCAD9AE0095134B /* and.swift in Sources */,
 				62512C781F0EAF950083A89F /* repeatWithBehavior.swift in Sources */,
@@ -1086,6 +1099,7 @@
 				62512C9B1F0EB1850083A89F /* NotTests.swift in Sources */,
 				62512C901F0EB17D0083A89F /* MapToTests+RxCocoa.swift in Sources */,
 				62512C961F0EB1850083A89F /* IgnoreErrorsTests.swift in Sources */,
+				C51708D82226F6B00058EF47 /* OverridingScanTests.swift in Sources */,
 				BF515CE61F3F3AF500492640 /* FromAsyncTests.swift in Sources */,
 				62512CA41F0EB1850083A89F /* FilterMapTests.swift in Sources */,
 				D7C72A3F1FDC5C5D00EAAAAB /* NwiseTests.swift in Sources */,
@@ -1132,6 +1146,7 @@
 				E39C41E71F18B08A007F2ACD /* pausable.swift in Sources */,
 				E39C41E31F18B08A007F2ACD /* materialized+elements.swift in Sources */,
 				C4D2154620118FC1009804AE /* ofType.swift in Sources */,
+				C51708D52226F3DD0058EF47 /* overridingScan.swift in Sources */,
 				E39C41DF1F18B08A007F2ACD /* ignore.swift in Sources */,
 				3D11958C1FCAD9AF0095134B /* and.swift in Sources */,
 				E39C41E91F18B08A007F2ACD /* repeatWithBehavior.swift in Sources */,
@@ -1163,6 +1178,7 @@
 				E39C42021F18B13E007F2ACD /* CatchErrorJustCompleteTests.swift in Sources */,
 				E39C420F1F18B13E007F2ACD /* UnwrapTests.swift in Sources */,
 				E39C42121F18B13E007F2ACD /* FilterMapTests.swift in Sources */,
+				C51708D92226F6B00058EF47 /* OverridingScanTests.swift in Sources */,
 				BF515CE71F3F3AF500492640 /* FromAsyncTests.swift in Sources */,
 				E39C41FF1F18B13A007F2ACD /* NotTests+RxCocoa.swift in Sources */,
 				D7C72A401FDC5C5D00EAAAAB /* NwiseTests.swift in Sources */,

--- a/Source/RxSwift/overridingScan.swift
+++ b/Source/RxSwift/overridingScan.swift
@@ -9,22 +9,34 @@
 import RxSwift
 
 private enum OverridingScanValue<T, U> {
-    case ongoing(T)
+    case sequential(T)
     case overriding(U)
 }
 
 extension ObservableType {
 
+    /**
+     Applies an accumulator function over an observable sequence and returns each intermediate result that can be overridden by values from another observable.
+     
+     The behavior is identical to `scan`, except the result of applying the accumulator function can be overridden by an arbitrary value from another observable.
+     
+     - seealso: [scan operator on reactivex.io](http://reactivex.io/documentation/operators/scan.html)
+     
+     - parameter overridingObservable: An observable which can override the current result of the accumulator function.
+     - parameter seed: The initial accumulator value.
+     - parameter accumulator: An accumulator function to be invoked on each element.
+     - returns: An observable sequence containing the accumulated values.
+     */
     public func overridingScan<T, U: ObservableType>(_ overridingObservable: U,
                                                      _ seed: T,
                                                      accumulator: @escaping (T, Self.E) throws -> T )
         -> Observable<T> where U.E == T {
             return Observable.merge(
-                self.map { OverridingScanValue<Self.E, T>.ongoing($0) },
+                self.map { OverridingScanValue<Self.E, T>.sequential($0) },
                 overridingObservable.map { OverridingScanValue<Self.E, T>.overriding($0) })
                 .scan(seed, accumulator: { (total, current) -> T in
                     switch current {
-                    case .ongoing(let value):
+                    case .sequential(let value):
                         return try accumulator(total, value)
                     case .overriding(let value):
                         return value

--- a/Source/RxSwift/overridingScan.swift
+++ b/Source/RxSwift/overridingScan.swift
@@ -1,0 +1,35 @@
+//
+//  overridingScan.swift
+//  RxSwiftExt
+//
+//  Created by Sergey Smagleev on 02/27/19.
+//  Copyright © 2019 RxSwift Community. All rights reserved.
+//
+
+import RxSwift
+
+private enum OverridingScanValue<T, U> {
+    case ongoing(T)
+    case overriding(U)
+}
+
+extension ObservableType {
+
+    public func overridingScan<T, U: ObservableType>(_ overridingObservable: U,
+                                                     _ seed: T,
+                                                     accumulator: @escaping (T, Self.E) throws -> T )
+        -> Observable<T> where U.E == T {
+            return Observable.merge(
+                self.map { OverridingScanValue<Self.E, T>.ongoing($0) },
+                overridingObservable.map { OverridingScanValue<Self.E, T>.overriding($0) })
+                .scan(seed, accumulator: { (total, current) -> T in
+                    switch current {
+                    case .ongoing(let value):
+                        return try accumulator(total, value)
+                    case .overriding(let value):
+                        return value
+                    }
+                })
+    }
+
+}

--- a/Tests/RxSwift/OverridingScanTests.swift
+++ b/Tests/RxSwift/OverridingScanTests.swift
@@ -12,37 +12,59 @@ import RxTest
 
 class OverridingScanTests: XCTestCase {
 
-    func testOverridingScan() {
+    func testOverridingScanInt() {
         let scheduler = TestScheduler(initialClock: 0)
-
         let overridingObservable = scheduler.createHotObservable([
-            next(250, 1),
             next(400, 10),
             completed(500)
             ])
-
         let observable = scheduler.createHotObservable([
             next(300, 2),
             next(350, 3),
             next(450, 4),
-            completed(500)
+            completed(550)
             ])
-
         let res = scheduler.start {
             return observable.overridingScan(overridingObservable, 0) { (total, current) -> Int in
                 return total + current
             }
         }
-
         let correct = [
-            next(250, 1),
-            next(300, 3),
-            next(350, 6),
+            next(300, 2),
+            next(350, 5),
             next(400, 10),
             next(450, 14),
-            completed(500)
+            completed(550)
         ]
+        XCTAssertEqual(res.events, correct)
+    }
 
+    func testOverridingScanArray() {
+        let scheduler = TestScheduler(initialClock: 0)
+        let overridingObservable = scheduler.createHotObservable([
+            next(250, [1]),
+            next(400, [2, 4]),
+            completed(550)
+            ])
+        let observable = scheduler.createHotObservable([
+            next(300, [3, 6]),
+            next(350, [7]),
+            next(450, [22, 8]),
+            completed(500)
+            ])
+        let res = scheduler.start {
+            return observable.overridingScan(overridingObservable, []) { (total, current) -> [Int] in
+                return total + current
+            }
+        }
+        let correct = [
+            next(250, [1]),
+            next(300, [1, 3, 6]),
+            next(350, [1, 3, 6, 7]),
+            next(400, [2, 4]),
+            next(450, [2, 4, 22, 8]),
+            completed(550)
+        ]
         XCTAssertEqual(res.events, correct)
     }
 

--- a/Tests/RxSwift/OverridingScanTests.swift
+++ b/Tests/RxSwift/OverridingScanTests.swift
@@ -1,0 +1,49 @@
+//
+//  OverridingScanTests.swift
+//  RxSwiftExt
+//
+//  Created by Sergey Smagleev on 02/27/19.
+//  Copyright © 2019 RxSwift Community. All rights reserved.
+//
+
+import XCTest
+import RxSwift
+import RxTest
+
+class OverridingScanTests: XCTestCase {
+
+    func testOverridingScan() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let overridingObservable = scheduler.createHotObservable([
+            next(250, 1),
+            next(400, 10),
+            completed(500)
+            ])
+
+        let observable = scheduler.createHotObservable([
+            next(300, 2),
+            next(350, 3),
+            next(450, 4),
+            completed(500)
+            ])
+
+        let res = scheduler.start {
+            return observable.overridingScan(overridingObservable, 0) { (total, current) -> Int in
+                return total + current
+            }
+        }
+
+        let correct = [
+            next(250, 1),
+            next(300, 3),
+            next(350, 6),
+            next(400, 10),
+            next(450, 14),
+            completed(500)
+        ]
+
+        XCTAssertEqual(res.events, correct)
+    }
+
+}


### PR DESCRIPTION
Greetings!

I came up with an operator I would like to propose. The WIP name is `overridingScan`, but I would gladly consider better names you might suggest. The idea behind it is to make an operator that works the same way `scan` does, but so that an accumulated value can be reset to some other value that comes from a different observable, like so:
```
a       -----------------------(10)----------------->
                                |
b       -----(1)---(2)---(3)----|----(4)---(5)------>
              |     |     |     |     |     |
              \/    \/    \/    \/    \/    \/
scan(+) -----(1)---(3)---(6)---(10)--(14)--(19)--->
```
Here, the intermediate sum produced by applying the accumulation function of the `scan` operator over the sequence `b` is overridden by a value coming from the sequence `a`. Once this happens, this value becomes the new "seed" and the following accumulating operation uses it as the last sum for all the subsequent values from `b`.
This idea came to my mind when I wanted to achieve the behavior when the new items can be appended to an array using the `scan` operator, but so that the array can also be refreshed and filled with completely new values, e.g. scrolling down a table view loads new cells, but scrolling it up refreshes it entirely. Normally this is achieved using `a.flatMapLatest { b.scan(...).startWith($0) }`, but in this scenario `a` should always come before `b`. A possible workaround is `a.startWith(seed)`, but it will emit an initial value that might be unwanted.
The usefulness of this operator might seem questionable, but I decided to propose it anyway. This PR doesn't include a readme section or a playground demo yet.

Any feedback is greatly appreciated!