### PR TITLE
[feature/fromAsync] add from async for single

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ master
 -----
 - added `partition(_:)` operator
 - added `bufferWithTrigger` operator
+- added `fromAsync` operator for `Single`
 
 3.4.0
 -----

--- a/Source/RxSwift/fromAsync.swift
+++ b/Source/RxSwift/fromAsync.swift
@@ -66,3 +66,70 @@ extension Observable {
         return { (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J) in Observable.fromAsync(curry(asyncRequest)(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)) }
     }
 }
+
+public enum FromAsyncError: Error {
+    /// Both result & error can't be nil
+    case inconsistentCompletionResult
+}
+
+public extension PrimitiveSequenceType where TraitType == SingleTrait {
+    /**
+     Transforms an async function that returns data or error through a completionHandler in a function that returns data through a Single
+     - The returned function will thake the same arguments than asyncRequest, minus the last one
+     */
+    static func fromAsync<Er: Error>(_ asyncRequest: @escaping (@escaping (ElementType?, Er?) -> Void) -> Void) -> Single<ElementType> {
+        return .create { single in
+            asyncRequest { result, error in
+                switch (result, error) {
+                case let (.some(result), nil):
+                    single(.success(result))
+                case let (nil, .some(error)):
+                    single(.error(error))
+                default:
+                    single(.error(FromAsyncError.inconsistentCompletionResult))
+                }
+            }
+            return Disposables.create()
+        }
+    }
+
+    static func fromAsync<A, Er: Error>(_ asyncRequest: @escaping (A, @escaping (ElementType?, Er?) -> Void) -> Void) -> (A) -> Single<ElementType> {
+        return { (a: A) in Single.fromAsync(curry(asyncRequest)(a)) }
+    }
+
+    static func fromAsync<A, B, Er: Error>(_ asyncRequest: @escaping (A, B, @escaping (ElementType?, Er?) -> Void) -> Void) -> (A, B) -> Single<ElementType> {
+        return { (a: A, b: B) in Single.fromAsync(curry(asyncRequest)(a)(b)) }
+    }
+
+    static func fromAsync<A, B, C, Er: Error>(_ asyncRequest: @escaping (A, B, C, @escaping (ElementType?, Er?) -> Void) -> Void) -> (A, B, C) -> Single<ElementType> {
+        return { (a: A, b: B, c: C) in Single.fromAsync(curry(asyncRequest)(a)(b)(c)) }
+    }
+
+    static func fromAsync<A, B, C, D, Er: Error>(_ asyncRequest: @escaping (A, B, C, D, @escaping (ElementType?, Er?) -> Void) -> Void) -> (A, B, C, D) -> Single<ElementType> {
+        return { (a: A, b: B, c: C, d: D) in Single.fromAsync(curry(asyncRequest)(a)(b)(c)(d)) }
+    }
+
+    static func fromAsync<A, B, C, D, E, Er: Error>(_ asyncRequest: @escaping (A, B, C, D, E, @escaping (ElementType?, Er?) -> Void) -> Void) -> (A, B, C, D, E) -> Single<ElementType> {
+        return { (a: A, b: B, c: C, d: D, e: E) in Single.fromAsync(curry(asyncRequest)(a)(b)(c)(d)(e)) }
+    }
+
+    static func fromAsync<A, B, C, D, E, F, Er: Error>(_ asyncRequest: @escaping (A, B, C, D, E, F, @escaping (ElementType?, Er?) -> Void) -> Void) -> (A, B, C, D, E, F) -> Single<ElementType> {
+        return { (a: A, b: B, c: C, d: D, e: E, f: F) in Single.fromAsync(curry(asyncRequest)(a)(b)(c)(d)(e)(f)) }
+    }
+    
+    static func fromAsync<A, B, C, D, E, F, G, Er: Error>(_ asyncRequest: @escaping (A, B, C, D, E, F, G, @escaping (ElementType?, Er?) -> Void) -> Void) -> (A, B, C, D, E, F, G) -> Single<ElementType> {
+        return { (a: A, b: B, c: C, d: D, e: E, f: F, g: G) in Single.fromAsync(curry(asyncRequest)(a)(b)(c)(d)(e)(f)(g)) }
+    }
+
+    static func fromAsync<A, B, C, D, E, F, G, H, Er: Error>(_ asyncRequest: @escaping (A, B, C, D, E, F, G, H, @escaping (ElementType?, Er?) -> Void) -> Void) -> (A, B, C, D, E, F, G, H) -> Single<ElementType> {
+        return { (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H) in Single.fromAsync(curry(asyncRequest)(a)(b)(c)(d)(e)(f)(g)(h)) }
+    }
+
+    static func fromAsync<A, B, C, D, E, F, G, H, I, Er: Error>(_ asyncRequest: @escaping (A, B, C, D, E, F, G, H, I, @escaping (ElementType?, Er?) -> Void) -> Void) -> (A, B, C, D, E, F, G, H, I) -> Single<ElementType> {
+        return { (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I) in Single.fromAsync(curry(asyncRequest)(a)(b)(c)(d)(e)(f)(g)(h)(i)) }
+    }
+
+    static func fromAsync<A, B, C, D, E, F, G, H, I, J, Er: Error>(_ asyncRequest: @escaping (A, B, C, D, E, F, G, H, I, J, @escaping (ElementType?, Er?) -> Void) -> Void) -> (A, B, C, D, E, F, G, H, I, J) -> Single<ElementType> {
+        return { (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J) in Single.fromAsync(curry(asyncRequest)(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)) }
+    }
+}

--- a/Tests/RxSwift/fromAsyncTests.swift
+++ b/Tests/RxSwift/fromAsyncTests.swift
@@ -13,8 +13,19 @@ import RxSwiftExt
 import RxTest
 
 class FromAsyncTests: XCTestCase {
-    private func service(arg1: String, arg2: Int, completionHandler: (String) -> Void) {
-        completionHandler("Result")
+    private var scheduler: TestScheduler!
+    private var observer: TestableObserver<String>!
+    
+    override func setUp() {
+        super.setUp()
+        scheduler = TestScheduler(initialClock: 0)
+        observer = scheduler.createObserver(String.self)
+    }
+    
+    override func tearDown() {
+        scheduler = nil
+        observer = nil
+        super.tearDown()
     }
 
     func testResultEquality() {
@@ -25,9 +36,6 @@ class FromAsyncTests: XCTestCase {
             correct.append(completed(0))
         }
 
-        let scheduler = TestScheduler(initialClock: 0)
-        let observer = scheduler.createObserver(String.self)
-
         _ = Observable
             .fromAsync(service(arg1:arg2:completionHandler:))("Foo", 2)
             .subscribe(observer)
@@ -35,5 +43,71 @@ class FromAsyncTests: XCTestCase {
         scheduler.start()
 
         XCTAssertEqual(observer.events, correct)
+    }
+    
+    func testSingleResultEqualitySuccessCase() {
+        // given
+        let result = "result"
+        let expectedEvents: [Recorded<Event<String>>] = [.next(0, result), .completed(0)]
+        // when
+        _ = Single<String>
+            .fromAsync(serviceWithError)(result)
+            .asObservable()
+            .subscribe(observer)
+        scheduler.start()
+        // then
+        XCTAssertEqual(observer.events, expectedEvents)
+    }
+    
+    func testSingleOptionalResultEqualitySuccessCase() {
+        // given
+        let result: String? = nil
+        let expectedEvents: [Recorded<Event<String?>>] = [.next(0, result), .completed(0)]
+        let observer = scheduler.createObserver(Optional<String>.self)
+        // when
+        _ = Single<String?>
+            .fromAsync(serviceWithOptionalResult)(result)
+            .asObservable()
+            .subscribe(observer)
+        scheduler.start()
+        // then
+        XCTAssertEqual(observer.events, expectedEvents)
+    }
+    
+    func testSingleResultEqualityErrorCase() {
+        // given
+        let expectedEvents: [Recorded<Event<String>>] = [.error(0, TestError())]
+        // when
+        _ = Single<String>
+            .fromAsync(serviceThrowingError)
+            .asObservable()
+            .subscribe(observer)
+        scheduler.start()
+        // then
+        XCTAssertEqual(observer.events, expectedEvents)
+    }
+    
+    // MARK: - Private utils
+    private struct TestError: Error {
+    }
+    
+    private func service(arg1: String, arg2: Int, completionHandler: (String) -> Void) {
+        completionHandler("Result")
+    }
+    
+    private func serviceWithError(result: String, completionHandler: (String?, TestError?) -> Void) {
+        completionHandler(result, nil)
+    }
+    
+    private func serviceWithOptionalResult(result: String?, completionHandler: (String??, TestError?) -> Void) {
+        completionHandler(result, nil)
+    }
+    
+    private func serviceThrowingError(completionHandler: (String?, TestError?) -> Void) {
+        completionHandler(nil, TestError())
+    }
+    
+    private func serviceWithOptionalResult(completionHandler: (String??, TestError?) -> Void) {
+        completionHandler(.some(nil), nil)
     }
 }


### PR DESCRIPTION
I think the current implementation of `fromAsync` might be a little more useful. Completion handlers used to be `(result: T, error: CustomError)` closures. Also completion handler should emit only once. So i used `Single` to implement that