### PR TITLE
RxSwiftExt 4.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       XCODE_TEST_REPORTS: /tmp/xcode-test-results
       LANG: en_US.UTF-8
     macos:
-      xcode: '9.4.0'
+      xcode: '10.2.0'
     steps:
       - checkout
       - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS $XCODE_TEST_REPORTS
@@ -42,7 +42,7 @@ jobs:
     environment:
       LANG: en_US.UTF-8
     macos:
-      xcode: '9.2.0'
+      xcode: '10.2.0'
     steps:
       - checkout
       - run:

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ profile
 DerivedData
 *.hmap
 *.ipa
+*.o
 
 # Bundler
 .bundle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,20 @@
 Changelog
 =========
 
-master
+5.0.0
 -----
+- Update to RxSwift 5.0.
+- Requires the Swift 5 compiler (Xcode 10.2 and up).i
 - added `partition(_:)` operator
 - added `bufferWithTrigger` operator
 - added `fromAsync` operator for `Single`
+
+4.0.0
+------
+Version 4.x has been skipped to align with RxSwift versioning.
+
+RxSwiftExt 5.x supports Swift 5.x
+RxSwiftExt 3.x supports Swift 4.x
 
 3.4.0
 -----

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReactiveX/RxSwift" ~> 4.0
+github "ReactiveX/RxSwift" ~> 5.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "ReactiveX/RxSwift" "4.4.0"
+github "ReactiveX/RxSwift" "5.0.1"

--- a/Readme.md
+++ b/Readme.md
@@ -10,17 +10,16 @@ If you're using [RxSwift](https://github.com/ReactiveX/RxSwift), you may have en
 Installation
 ===========
 
-This branch of RxSwiftExt targets Swift 4.x and RxSwift 4.0.0 or later.
+This branch of RxSwiftExt targets Swift 5.x and RxSwift 5.0.0 or later.
 
-* If you're looking for the Swift 3 version of RxSwiftExt, please use version `2.5.1` of the framework.
-* If your project is running on Swift 2.x, please use version `1.2` of the framework.
+* If you're looking for the Swift 4 version of RxSwiftExt, please use version `3.4.0` of the framework.
 
 #### CocoaPods
 
-Using Swift 4:
+Add to your `Podfile`:
 
 ```ruby
-pod 'RxSwiftExt'
+pod 'RxSwiftExt', '~> 5'
 ```
 
 This will install both the `RxSwift` and `RxCocoa` extensions.
@@ -30,16 +29,10 @@ If you're interested in only installing the `RxSwift` extensions, without the `R
 pod 'RxSwiftExt/Core'
 ```
 
-Using Swift 3:
+Using Swift 4:
 
 ```ruby
-pod 'RxSwiftExt', '2.5.1'
-```
-
-If you use Swift 2.x:
-
-```ruby
-pod 'RxSwiftExt', '1.2'
+pod 'RxSwiftExt', '~> 3'
 ```
 
 #### Carthage
@@ -653,6 +646,6 @@ slider.rx.value.map(CGFloat.init)
 ```
 ## License
 
-This library belongs to _RxSwiftCommunity_.
+This library belongs to _RxSwift Community_.
 
 RxSwiftExt is available under the MIT license. See the LICENSE file for more info.

--- a/RxSwiftExt.podspec
+++ b/RxSwiftExt.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "RxSwiftExt"
-  s.version      = "3.4.0"
+  s.version      = "5.0.0"
   s.summary      = "RxSwift operators not found in the core distribtion"
   s.description  = <<-DESC
     A collection of operators for RxSwift adding commonly requested operations not found in the core distribution
@@ -20,13 +20,13 @@ Pod::Spec.new do |s|
   s.subspec "Core" do |cs|
     cs.source_files  = "Source/RxSwift", "Source/Tools"
     cs.frameworks  = "Foundation"
-    cs.dependency "RxSwift", '~> 4.0'
+    cs.dependency "RxSwift", '~> 5.0'
   end
 
   s.subspec "RxCocoa" do |co|
     co.source_files  = "Source/RxCocoa"
     co.frameworks  = "Foundation"
-    co.dependency "RxCocoa", '~> 4.0'
+    co.dependency "RxCocoa", '~> 5.0'
     co.dependency "RxSwiftExt/Core"
   end
 end

--- a/RxSwiftExt.xcodeproj/project.pbxproj
+++ b/RxSwiftExt.xcodeproj/project.pbxproj
@@ -162,6 +162,7 @@
 		A23E149321A9F73500CD5B2F /* PartitionTests+RxCocoa.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23E149221A9F73500CD5B2F /* PartitionTests+RxCocoa.swift */; };
 		A23E149421A9F73500CD5B2F /* PartitionTests+RxCocoa.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23E149221A9F73500CD5B2F /* PartitionTests+RxCocoa.swift */; };
 		A23E149521A9F73500CD5B2F /* PartitionTests+RxCocoa.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23E149221A9F73500CD5B2F /* PartitionTests+RxCocoa.swift */; };
+		A2A68C992278AF6800586188 /* RxRelay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A2A68C972278AF5000586188 /* RxRelay.framework */; };
 		B69B45492190C27D00F30418 /* count.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69B45482190C27D00F30418 /* count.swift */; };
 		B69B454A2190C3AE00F30418 /* count.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69B45482190C27D00F30418 /* count.swift */; };
 		B69B454B2190C3AF00F30418 /* count.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69B45482190C27D00F30418 /* count.swift */; };
@@ -358,6 +359,7 @@
 		A23E148A21A9F03600CD5B2F /* partition+RxCocoa.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "partition+RxCocoa.swift"; sourceTree = "<group>"; };
 		A23E148E21A9F10D00CD5B2F /* PartitionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PartitionTests.swift; sourceTree = "<group>"; };
 		A23E149221A9F73500CD5B2F /* PartitionTests+RxCocoa.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PartitionTests+RxCocoa.swift"; sourceTree = "<group>"; };
+		A2A68C972278AF5000586188 /* RxRelay.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxRelay.framework; path = Carthage/Build/iOS/RxRelay.framework; sourceTree = "<group>"; };
 		B69B45482190C27D00F30418 /* count.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = count.swift; sourceTree = "<group>"; };
 		B69B454C2190C3BC00F30418 /* CountTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountTests.swift; sourceTree = "<group>"; };
 		BF515CDF1F3F370600492640 /* curry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = curry.swift; path = Source/Tools/curry.swift; sourceTree = SOURCE_ROOT; };
@@ -393,6 +395,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3D638E1D1DC2B36A0089A590 /* RxSwift.framework in Frameworks */,
+				A2A68C992278AF6800586188 /* RxRelay.framework in Frameworks */,
 				3D638DEC1DC2B2D50089A590 /* RxSwiftExt.framework in Frameworks */,
 				3D638E1F1DC2B3A40089A590 /* RxTest.framework in Frameworks */,
 			);
@@ -607,6 +610,7 @@
 		9DAB77991D6763AC007E85BC /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				A2A68C972278AF5000586188 /* RxRelay.framework */,
 				1AA8395A207451D5001C49ED /* RxCocoa.framework */,
 				E36BDFB81F38755F008C9D56 /* tvOS */,
 				62512C561F0EAEB90083A89F /* macOS */,
@@ -780,7 +784,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0830;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = RxSwiftCommunity;
 				TargetAttributes = {
 					188C6D901C47B2B20092101A = {
@@ -820,7 +824,7 @@
 			};
 			buildConfigurationList = 18EE7A131C47B12F00C7256C /* Build configuration list for PBXProject "RxSwiftExt" */;
 			compatibilityVersion = "Xcode 8.0";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
@@ -897,12 +901,13 @@
 				"$(SRCROOT)/Carthage/Build/Mac/RxSwift.framework",
 				"$(SRCROOT)/Carthage/Build/Mac/RxTest.framework",
 				"$(SRCROOT)/Carthage/Build/Mac/RxCocoa.framework",
+				"$(SRCROOT)/Carthage/Build/Mac/RxRelay.framework",
 			);
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
+			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
 			showEnvVarsInLog = 0;
 		};
 		6E407C291DCF8E4C008D2828 /* Copy carthage frameworks */ = {
@@ -914,13 +919,14 @@
 				"$(SRCROOT)/Carthage/Build/iOS/RxSwift.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/RxTest.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/RxCocoa.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/RxRelay.framework",
 			);
 			name = "Copy carthage frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
+			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
 		};
 		87B3D2C1203EB014001327A4 /* Swiftlint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -986,13 +992,14 @@
 				"$(SRCROOT)/Carthage/Build/tvOS/RxSwift.framework",
 				"$(SRCROOT)/Carthage/Build/tvOS/RxTest.framework",
 				"$(SRCROOT)/Carthage/Build/tvOS/RxCocoa.framework",
+				"$(SRCROOT)/Carthage/Build/tvOS/RxRelay.framework",
 			);
 			name = "Copy carthage frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
+			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -1306,6 +1313,7 @@
 				PRODUCT_NAME = RxSwiftExt;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -1336,6 +1344,7 @@
 				PRODUCT_NAME = RxSwiftExt;
 				SKIP_INSTALL = YES;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -1393,7 +1402,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -1440,7 +1449,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -1510,6 +1519,7 @@
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1544,6 +1554,7 @@
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};

--- a/RxSwiftExt.xcodeproj/xcshareddata/xcschemes/RxSwiftExt-iOS.xcscheme
+++ b/RxSwiftExt.xcodeproj/xcshareddata/xcschemes/RxSwiftExt-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -40,7 +40,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -70,7 +69,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/RxSwiftExt.xcodeproj/xcshareddata/xcschemes/RxSwiftExt-macOS.xcscheme
+++ b/RxSwiftExt.xcodeproj/xcshareddata/xcschemes/RxSwiftExt-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -56,7 +55,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/RxSwiftExt.xcodeproj/xcshareddata/xcschemes/RxSwiftExt-tvOS.xcscheme
+++ b/RxSwiftExt.xcodeproj/xcshareddata/xcschemes/RxSwiftExt-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -56,7 +55,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/RxSwiftExt.xcodeproj/xcshareddata/xcschemes/RxSwiftExtPlayground.xcscheme
+++ b/RxSwiftExt.xcodeproj/xcshareddata/xcschemes/RxSwiftExtPlayground.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -37,7 +36,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/RxSwiftExt.xcodeproj/xcshareddata/xcschemes/RxSwiftExtTests-iOS.xcscheme
+++ b/RxSwiftExt.xcodeproj/xcshareddata/xcschemes/RxSwiftExtTests-iOS.xcscheme
@@ -1,14 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
+            buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForTesting = "YES">
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "3D638DE61DC2B2D40089A590"
@@ -23,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -44,13 +46,21 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3D638DE61DC2B2D40089A590"
+            BuildableName = "RxSwiftExtTests-iOS.xctest"
+            BlueprintName = "RxSwiftExtTests-iOS"
+            ReferencedContainer = "container:RxSwiftExt.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/RxSwiftExt.xcodeproj/xcshareddata/xcschemes/RxSwiftExtTests-macOS.xcscheme
+++ b/RxSwiftExt.xcodeproj/xcshareddata/xcschemes/RxSwiftExtTests-macOS.xcscheme
@@ -1,14 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
+            buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForTesting = "YES">
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "62512C831F0EB1280083A89F"
@@ -23,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -44,13 +46,21 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "62512C831F0EB1280083A89F"
+            BuildableName = "RxSwiftExtTests-macOS.xctest"
+            BlueprintName = "RxSwiftExtTests-macOS"
+            ReferencedContainer = "container:RxSwiftExt.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/Source/RxCocoa/UIViewPropertyAnimator+Rx.swift
+++ b/Source/RxCocoa/UIViewPropertyAnimator+Rx.swift
@@ -17,7 +17,7 @@ public extension Reactive where Base: UIViewPropertyAnimator {
     /**
      Bindable extension for `fractionComplete` property.
      */
-    public var fractionComplete: Binder<CGFloat> {
+    var fractionComplete: Binder<CGFloat> {
         return Binder(base) { propertyAnimator, fractionComplete in
             propertyAnimator.fractionComplete = fractionComplete
         }

--- a/Source/RxCocoa/not+RxCocoa.swift
+++ b/Source/RxCocoa/not+RxCocoa.swift
@@ -8,7 +8,7 @@
 
 import RxCocoa
 
-extension SharedSequenceConvertibleType where E == Bool {
+extension SharedSequenceConvertibleType where Element == Bool {
     /// Boolean not operator.
     public func not() -> SharedSequence<SharingStrategy, Bool> {
         return map(!)

--- a/Source/RxCocoa/partition+RxCocoa.swift
+++ b/Source/RxCocoa/partition+RxCocoa.swift
@@ -3,7 +3,7 @@
 //  RxSwiftExt
 //
 //  Created by Shai Mishali on 24/11/2018.
-//  Copyright © 2018 RxSwiftCommunity. All rights reserved.
+//  Copyright © 2018 RxSwift Community. All rights reserved.
 //
 
 import RxSwift
@@ -17,8 +17,8 @@ public extension SharedSequence {
 
      - returns: A tuple of two streams of elements that match, and don't match, the provided predicate.
      */
-    func partition(_ predicate: @escaping (E) -> Bool) -> (matches: SharedSequence<S, E>,
-                                                           nonMatches: SharedSequence<S, E>) {
+    func partition(_ predicate: @escaping (Element) -> Bool) -> (matches: SharedSequence<SharingStrategy, Element>,
+                                                                 nonMatches: SharedSequence<SharingStrategy, Element>) {
         let stream = self.map { ($0, predicate($0)) }
 
         let hits = stream.filter { $0.1 }.map { $0.0 }

--- a/Source/RxCocoa/unwrap+SharedSequence.swift
+++ b/Source/RxCocoa/unwrap+SharedSequence.swift
@@ -16,7 +16,7 @@ extension SharedSequence {
      - returns: A SharedSequence of non-optional elements
      */
 
-    public func unwrap<T>() -> SharedSequence<S, T> where E == T? {
+    public func unwrap<T>() -> SharedSequence<SharingStrategy, T> where Element == T? {
         return self.filter { $0 != nil }.map { $0! }
     }
 }

--- a/Source/RxSwift/ObservableType+Weak.swift
+++ b/Source/RxSwift/ObservableType+Weak.swift
@@ -37,7 +37,7 @@ extension ObservableType {
 	- parameter on: Function to invoke on `weak` for each event in the observable sequence.
 	- returns: Subscription object used to unsubscribe from the observable sequence.
 	*/
-	public func subscribe<A: AnyObject>(weak obj: A, _ on: @escaping (A) -> (RxSwift.Event<Self.E>) -> Void) -> Disposable {
+	public func subscribe<A: AnyObject>(weak obj: A, _ on: @escaping (A) -> (Event<Element>) -> Void) -> Disposable {
 		return self.subscribe(weakify(obj, method: on))
 	}
 
@@ -54,7 +54,7 @@ extension ObservableType {
 	*/
 	public func subscribe<A: AnyObject>(
                     weak obj: A,
-                    onNext: ((A) -> (Self.E) -> Void)? = nil,
+                    onNext: ((A) -> (Element) -> Void)? = nil,
                     onError: ((A) -> (Error) -> Void)? = nil,
                     onCompleted: ((A) -> () -> Void)? = nil,
                     onDisposed: ((A) -> () -> Void)? = nil)
@@ -67,7 +67,7 @@ extension ObservableType {
 			disposable = Disposables.create()
 		}
 
-		let observer = AnyObserver { [weak obj] (e: RxSwift.Event<Self.E>) in
+		let observer = AnyObserver { [weak obj] (e: Event<Element>) in
 			guard let obj = obj else { return }
 			switch e {
 			case .next(let value):
@@ -91,7 +91,7 @@ extension ObservableType {
 	- parameter onNext: Function to invoke on `weak` for each element in the observable sequence.
 	- returns: Subscription object used to unsubscribe from the observable sequence.
 	*/
-	public func subscribeNext<A: AnyObject>(weak obj: A, _ onNext: @escaping (A) -> (Self.E) -> Void) -> Disposable {
+	public func subscribeNext<A: AnyObject>(weak obj: A, _ onNext: @escaping (A) -> (Element) -> Void) -> Disposable {
         return self.subscribe(onNext: weakify(obj, method: onNext))
 	}
 

--- a/Source/RxSwift/and.swift
+++ b/Source/RxSwift/and.swift
@@ -9,7 +9,7 @@
 import Foundation
 import RxSwift
 
-extension ObservableType where E == Bool {
+extension ObservableType where Element == Bool {
 	/**
 	Emits a single Bool value indicating whether or not a Bool sequence emits only `true` values.
 
@@ -20,7 +20,7 @@ extension ObservableType where E == Bool {
 
 	Use `asSingle()` or `asObservable()` to convert to your requirements.
 	*/
-	public func and() -> Maybe<E> {
+	public func and() -> Maybe<Element> {
 		return Maybe.create { observer in
 			var gotValue = false
 			return self.subscribe { event in
@@ -51,7 +51,7 @@ extension ObservableType where E == Bool {
 
 	Use `asSingle()` or `asObservable()` to convert to your requirements.
 	*/
-	public static func and<C: Collection>(_ collection: C) -> Maybe<E> where C.Element: ObservableType, C.Element.E == E {
+	public static func and<C: Collection>(_ collection: C) -> Maybe<Element> where C.Element: ObservableType, C.Element.Element == Element {
 		return Maybe.create { observer in
 			var emitted = [Bool](repeating: false, count: Int(collection.count))
 			var completed = 0
@@ -99,7 +99,7 @@ extension ObservableType where E == Bool {
 
 	Use `asSingle()` or `asObservable()` to convert to your requirements.
 	*/
-	public static func and<O: ObservableType>(_ sources: O ...) -> Maybe<E> where O.E == E {
+	public static func and<O: ObservableType>(_ sources: O ...) -> Maybe<Element> where O.Element == Element {
 		return and(sources)
 	}
 }

--- a/Source/RxSwift/apply.swift
+++ b/Source/RxSwift/apply.swift
@@ -11,14 +11,14 @@ import RxSwift
 
 extension ObservableType {
     /// Apply a transformation function to the Observable.
-    public func apply<T>(_ transform: (Observable<Self.E>) -> Observable<T>) -> Observable<T> {
+    public func apply<Result>(_ transform: (Observable<Element>) -> Observable<Result>) -> Observable<Result> {
         return transform(self.asObservable())
     }
 }
 
-extension PrimitiveSequenceType where TraitType == SingleTrait {
+extension PrimitiveSequenceType where Trait == SingleTrait {
     /// Apply a transformation function to the Single.
-    public func apply<T>(_ transform: (Single<Self.ElementType>) -> Single<T>) -> Single<T> {
+    public func apply<T>(_ transform: (Single<Element>) -> Single<T>) -> Single<T> {
         return transform(self.primitiveSequence)
     }
 }

--- a/Source/RxSwift/bufferWithTrigger.swift
+++ b/Source/RxSwift/bufferWithTrigger.swift
@@ -1,9 +1,9 @@
 //
 //  bufferWithTrigger.swift
-//  RxSwiftExt-iOS
+//  RxSwiftExt
 //
 //  Created by Patrick Maltagliati on 11/12/18.
-//  Copyright © 2018 RxSwiftCommunity. All rights reserved.
+//  Copyright © 2018 RxSwift Community. All rights reserved.
 //
 
 import Foundation
@@ -16,9 +16,9 @@ extension ObservableType {
      - parameter trigger: The observable sequence used to signal the emission of the buffered items.
      - returns: The buffered observable from elements of the source sequence.
      */
-    public func bufferWithTrigger<U>(_ trigger: Observable<U>) -> Observable<[E]> {
-        return Observable<[E]>.create { observer in
-            var buffer: [E] = []
+    public func bufferWithTrigger<U>(_ trigger: Observable<U>) -> Observable<[Element]> {
+        return Observable.create { observer in
+            var buffer: [Element] = []
             let lock = NSRecursiveLock()
             let triggerDisposable = trigger.subscribe { event in
                 lock.lock(); defer { lock.unlock() }

--- a/Source/RxSwift/cascade.swift
+++ b/Source/RxSwift/cascade.swift
@@ -10,9 +10,6 @@ import Foundation
 import RxSwift
 
 extension Observable where Element: ObservableType {
-
-	public typealias T = Element.E
-
 	/**
 	Cascade through a sequence of observables: every observable that sends a `next` value becomes the "current"
 	observable (like in `switchLatest`), and the subscription to all previous observables in the sequence is disposed.
@@ -23,13 +20,13 @@ extension Observable where Element: ObservableType {
 	- parameter observables: a sequence of observables which will all be immediately subscribed to
 	- returns: An observable sequence that contains elements from the latest observable sequence that emitted elements
 	*/
-	public static func cascade<S: Sequence>(_ observables: S) -> Observable<T> where S.Iterator.Element == Element {
+	public static func cascade<S: Sequence>(_ observables: S) -> Observable<Element.Element> where S.Element == Element {
         let flow = Array(observables)
         if flow.isEmpty {
-            return Observable<T>.empty()
+            return Observable<Element.Element>.empty()
         }
 
-        return Observable<T>.create { observer in
+        return Observable<Element.Element>.create { observer in
             var current = 0, initialized = false
             var subscriptions: [SerialDisposable?] = flow.map { _ in SerialDisposable() }
 
@@ -104,7 +101,7 @@ extension ObservableType {
     - parameter observables: a sequence of observables which will all be immediately subscribed to
     - returns: An observable sequence that contains elements from the latest observable sequence that emitted elements
     */
-    public func cascade<S: Sequence>(_ next: S) -> Observable<E> where S.Iterator.Element == Self {
+    public func cascade<S: Sequence>(_ next: S) -> Observable<Element> where S.Element == Self {
         return Observable.cascade([self.asObservable()] + Array(next).map { $0.asObservable() })
     }
 }

--- a/Source/RxSwift/catchErrorJustComplete.swift
+++ b/Source/RxSwift/catchErrorJustComplete.swift
@@ -14,7 +14,7 @@ extension ObservableType {
      
      - returns: An observable sequence that never errors and completes when an error occurs in the underlying sequence
      */
-    public func catchErrorJustComplete() -> Observable<E> {
+    public func catchErrorJustComplete() -> Observable<Element> {
         return catchError { _ in
             return Observable.empty()
         }

--- a/Source/RxSwift/count.swift
+++ b/Source/RxSwift/count.swift
@@ -1,9 +1,9 @@
 //
 //  count.swift
-//  RxSwiftExt-iOS
+//  RxSwiftExt
 //
 //  Created by Fred on 06/11/2018.
-//  Copyright © 2018 RxSwiftCommunity. All rights reserved.
+//  Copyright © 2018 RxSwift Community. All rights reserved.
 //
 
 import Foundation

--- a/Source/RxSwift/distinct.swift
+++ b/Source/RxSwift/distinct.swift
@@ -17,7 +17,7 @@ extension Observable {
      
      - returns: An observable sequence only containing the distinct contiguous elements, based on predicate, from the source sequence.
      */
-    public func distinct(_ predicate: @escaping (Element) throws -> Bool) -> Observable<E> {
+    public func distinct(_ predicate: @escaping (Element) throws -> Bool) -> Observable<Element> {
         var cache = [Element]()
         return flatMap { element -> Observable<Element> in
             if try cache.contains(where: predicate) {

--- a/Source/RxSwift/filterMap.swift
+++ b/Source/RxSwift/filterMap.swift
@@ -29,7 +29,7 @@ extension ObservableType {
         - returning `.ignore` will filter the value out of the returned Observable
         - returning `.map(newValue)` will propagate newValue through the returned Observable.
      */
-    public func filterMap<T>(_ transform: @escaping (E) -> FilterMap<T>) -> Observable<T> {
+    public func filterMap<Result>(_ transform: @escaping (Element) -> FilterMap<Result>) -> Observable<Result> {
         return flatMapSync { transform($0).asOperator }
     }
 }

--- a/Source/RxSwift/flatMapSync.swift
+++ b/Source/RxSwift/flatMapSync.swift
@@ -58,7 +58,7 @@ extension ObservableType {
 
      see filterMap for an example of a custom operator
      */
-    public func flatMapSync<O: CustomOperator>(_ transform: @escaping (E) -> O) -> Observable<O.Result> {
+    public func flatMapSync<O: CustomOperator>(_ transform: @escaping (Element) -> O) -> Observable<O.Result> {
         return Observable.create { observer in
             return self.subscribe { event in
                 switch event {

--- a/Source/RxSwift/fromAsync.swift
+++ b/Source/RxSwift/fromAsync.swift
@@ -72,12 +72,12 @@ public enum FromAsyncError: Error {
     case inconsistentCompletionResult
 }
 
-public extension PrimitiveSequenceType where TraitType == SingleTrait {
+public extension PrimitiveSequenceType where Trait == SingleTrait {
     /**
      Transforms an async function that returns data or error through a completionHandler in a function that returns data through a Single
      - The returned function will thake the same arguments than asyncRequest, minus the last one
      */
-    static func fromAsync<Er: Error>(_ asyncRequest: @escaping (@escaping (ElementType?, Er?) -> Void) -> Void) -> Single<ElementType> {
+    static func fromAsync<Er: Error>(_ asyncRequest: @escaping (@escaping (Element?, Er?) -> Void) -> Void) -> Single<Element> {
         return .create { single in
             asyncRequest { result, error in
                 switch (result, error) {
@@ -93,43 +93,43 @@ public extension PrimitiveSequenceType where TraitType == SingleTrait {
         }
     }
 
-    static func fromAsync<A, Er: Error>(_ asyncRequest: @escaping (A, @escaping (ElementType?, Er?) -> Void) -> Void) -> (A) -> Single<ElementType> {
+    static func fromAsync<A, Er: Error>(_ asyncRequest: @escaping (A, @escaping (Element?, Er?) -> Void) -> Void) -> (A) -> Single<Element> {
         return { (a: A) in Single.fromAsync(curry(asyncRequest)(a)) }
     }
 
-    static func fromAsync<A, B, Er: Error>(_ asyncRequest: @escaping (A, B, @escaping (ElementType?, Er?) -> Void) -> Void) -> (A, B) -> Single<ElementType> {
+    static func fromAsync<A, B, Er: Error>(_ asyncRequest: @escaping (A, B, @escaping (Element?, Er?) -> Void) -> Void) -> (A, B) -> Single<Element> {
         return { (a: A, b: B) in Single.fromAsync(curry(asyncRequest)(a)(b)) }
     }
 
-    static func fromAsync<A, B, C, Er: Error>(_ asyncRequest: @escaping (A, B, C, @escaping (ElementType?, Er?) -> Void) -> Void) -> (A, B, C) -> Single<ElementType> {
+    static func fromAsync<A, B, C, Er: Error>(_ asyncRequest: @escaping (A, B, C, @escaping (Element?, Er?) -> Void) -> Void) -> (A, B, C) -> Single<Element> {
         return { (a: A, b: B, c: C) in Single.fromAsync(curry(asyncRequest)(a)(b)(c)) }
     }
 
-    static func fromAsync<A, B, C, D, Er: Error>(_ asyncRequest: @escaping (A, B, C, D, @escaping (ElementType?, Er?) -> Void) -> Void) -> (A, B, C, D) -> Single<ElementType> {
+    static func fromAsync<A, B, C, D, Er: Error>(_ asyncRequest: @escaping (A, B, C, D, @escaping (Element?, Er?) -> Void) -> Void) -> (A, B, C, D) -> Single<Element> {
         return { (a: A, b: B, c: C, d: D) in Single.fromAsync(curry(asyncRequest)(a)(b)(c)(d)) }
     }
 
-    static func fromAsync<A, B, C, D, E, Er: Error>(_ asyncRequest: @escaping (A, B, C, D, E, @escaping (ElementType?, Er?) -> Void) -> Void) -> (A, B, C, D, E) -> Single<ElementType> {
+    static func fromAsync<A, B, C, D, E, Er: Error>(_ asyncRequest: @escaping (A, B, C, D, E, @escaping (Element?, Er?) -> Void) -> Void) -> (A, B, C, D, E) -> Single<Element> {
         return { (a: A, b: B, c: C, d: D, e: E) in Single.fromAsync(curry(asyncRequest)(a)(b)(c)(d)(e)) }
     }
 
-    static func fromAsync<A, B, C, D, E, F, Er: Error>(_ asyncRequest: @escaping (A, B, C, D, E, F, @escaping (ElementType?, Er?) -> Void) -> Void) -> (A, B, C, D, E, F) -> Single<ElementType> {
+    static func fromAsync<A, B, C, D, E, F, Er: Error>(_ asyncRequest: @escaping (A, B, C, D, E, F, @escaping (Element?, Er?) -> Void) -> Void) -> (A, B, C, D, E, F) -> Single<Element> {
         return { (a: A, b: B, c: C, d: D, e: E, f: F) in Single.fromAsync(curry(asyncRequest)(a)(b)(c)(d)(e)(f)) }
     }
-    
-    static func fromAsync<A, B, C, D, E, F, G, Er: Error>(_ asyncRequest: @escaping (A, B, C, D, E, F, G, @escaping (ElementType?, Er?) -> Void) -> Void) -> (A, B, C, D, E, F, G) -> Single<ElementType> {
+
+    static func fromAsync<A, B, C, D, E, F, G, Er: Error>(_ asyncRequest: @escaping (A, B, C, D, E, F, G, @escaping (Element?, Er?) -> Void) -> Void) -> (A, B, C, D, E, F, G) -> Single<Element> {
         return { (a: A, b: B, c: C, d: D, e: E, f: F, g: G) in Single.fromAsync(curry(asyncRequest)(a)(b)(c)(d)(e)(f)(g)) }
     }
 
-    static func fromAsync<A, B, C, D, E, F, G, H, Er: Error>(_ asyncRequest: @escaping (A, B, C, D, E, F, G, H, @escaping (ElementType?, Er?) -> Void) -> Void) -> (A, B, C, D, E, F, G, H) -> Single<ElementType> {
+    static func fromAsync<A, B, C, D, E, F, G, H, Er: Error>(_ asyncRequest: @escaping (A, B, C, D, E, F, G, H, @escaping (Element?, Er?) -> Void) -> Void) -> (A, B, C, D, E, F, G, H) -> Single<Element> {
         return { (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H) in Single.fromAsync(curry(asyncRequest)(a)(b)(c)(d)(e)(f)(g)(h)) }
     }
 
-    static func fromAsync<A, B, C, D, E, F, G, H, I, Er: Error>(_ asyncRequest: @escaping (A, B, C, D, E, F, G, H, I, @escaping (ElementType?, Er?) -> Void) -> Void) -> (A, B, C, D, E, F, G, H, I) -> Single<ElementType> {
+    static func fromAsync<A, B, C, D, E, F, G, H, I, Er: Error>(_ asyncRequest: @escaping (A, B, C, D, E, F, G, H, I, @escaping (Element?, Er?) -> Void) -> Void) -> (A, B, C, D, E, F, G, H, I) -> Single<Element> {
         return { (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I) in Single.fromAsync(curry(asyncRequest)(a)(b)(c)(d)(e)(f)(g)(h)(i)) }
     }
 
-    static func fromAsync<A, B, C, D, E, F, G, H, I, J, Er: Error>(_ asyncRequest: @escaping (A, B, C, D, E, F, G, H, I, J, @escaping (ElementType?, Er?) -> Void) -> Void) -> (A, B, C, D, E, F, G, H, I, J) -> Single<ElementType> {
+    static func fromAsync<A, B, C, D, E, F, G, H, I, J, Er: Error>(_ asyncRequest: @escaping (A, B, C, D, E, F, G, H, I, J, @escaping (Element?, Er?) -> Void) -> Void) -> (A, B, C, D, E, F, G, H, I, J) -> Single<Element> {
         return { (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J) in Single.fromAsync(curry(asyncRequest)(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)) }
     }
 }

--- a/Source/RxSwift/ignore.swift
+++ b/Source/RxSwift/ignore.swift
@@ -9,13 +9,12 @@
 import Foundation
 import RxSwift
 
-extension ObservableType where E: Equatable {
-
-	public func ignore(_ valuesToIgnore: E ...) -> Observable<E> {
+extension ObservableType where Element: Equatable {
+	public func ignore(_ valuesToIgnore: Element...) -> Observable<Element> {
         return self.asObservable().filter { !valuesToIgnore.contains($0) }
     }
 
-	public func ignore<S: Sequence>(_ valuesToIgnore: S) -> Observable<E> where S.Iterator.Element == E {
+	public func ignore<Sequence: Swift.Sequence>(_ valuesToIgnore: Sequence) -> Observable<Element> where Sequence.Element == Element {
 		return self.asObservable().filter { !valuesToIgnore.contains($0) }
 	}
 }

--- a/Source/RxSwift/ignoreErrors.swift
+++ b/Source/RxSwift/ignoreErrors.swift
@@ -16,7 +16,7 @@ extension ObservableType {
      - returns: An observable sequence that never fails
      - seealso: `retry` operator
      */
-    public func ignoreErrors() -> Observable<E> {
+    public func ignoreErrors() -> Observable<Element> {
         return retry()
     }
 
@@ -26,7 +26,7 @@ extension ObservableType {
      - parameter predicate a predicate called when an error occurs and returns `true` to ignore the error (continuing), `false` to terminate the sequence with the given error.
      - returns: An observable sequence that errors only when `predicate` returns `false`
      */
-    public func ignoreErrors(_ predicate : @escaping (Error) -> Bool) -> Observable<E> {
+    public func ignoreErrors(_ predicate : @escaping (Error) -> Bool) -> Observable<Element> {
         return retryWhen {
             return $0.flatMap { error -> Observable<Bool> in
                 return predicate(error) ?  Observable.just(true) : Observable<Bool>.error(error)

--- a/Source/RxSwift/ignoreWhen.swift
+++ b/Source/RxSwift/ignoreWhen.swift
@@ -20,7 +20,7 @@ extension ObservableType {
 	- parameter predicate: A function to test each source element for a condition.
 	- returns: An observable sequence that contains elements from the input sequence except those that satisfy the condition.
 	*/
-	public func ignoreWhen(_ predicate: @escaping (E) throws -> Bool) -> Observable<E> {
+	public func ignoreWhen(_ predicate: @escaping (Element) throws -> Bool) -> Observable<Element> {
 		return self.asObservable().filter { try !predicate($0) }
 	}
 }

--- a/Source/RxSwift/mapAt.swift
+++ b/Source/RxSwift/mapAt.swift
@@ -16,7 +16,7 @@ extension ObservableType {
      - parameter keyPath: A key path whose root type matches the element type of the input sequence
      - returns: An observable squence containing the values pointed to by the key path
      */
-    public func mapAt<R>(_ keyPath: KeyPath<E, R>) -> Observable<R> {
+    public func mapAt<Result>(_ keyPath: KeyPath<Element, Result>) -> Observable<Result> {
         return self.map { $0[keyPath: keyPath] }
     }
 }

--- a/Source/RxSwift/mapMany.swift
+++ b/Source/RxSwift/mapMany.swift
@@ -8,15 +8,15 @@
 
 import RxSwift
 
-extension ObservableType where E: Collection {
+extension ObservableType where Element: Collection {
     /**
      Projects each element of an observable collection into a new form.
 
      - parameter transform: A transform function to apply to each element of the source collection.
      - returns: An observable collection whose elements are the result of invoking the transform function on each element of source.
      */
-    public func mapMany<T>(_ transform: @escaping (E.Element) throws -> T) -> Observable<[T]> {
-        return map { collection -> [T] in
+    public func mapMany<Result>(_ transform: @escaping (Element.Element) throws -> Result) -> Observable<[Result]> {
+        return map { collection -> [Result] in
             try collection.map(transform)
         }
     }

--- a/Source/RxSwift/materialized+elements.swift
+++ b/Source/RxSwift/materialized+elements.swift
@@ -9,13 +9,13 @@
 import Foundation
 import RxSwift
 
-extension ObservableType where E: EventConvertible {
+extension ObservableType where Element: EventConvertible {
 
 	/**
 	 Returns an observable sequence containing only next elements from its input
 	 - seealso: [materialize operator on reactivex.io](http://reactivex.io/documentation/operators/materialize-dematerialize.html)
 	 */
-	public func elements() -> Observable<E.ElementType> {
+	public func elements() -> Observable<Element.Element> {
 		return filter { $0.event.element != nil }
 				.map { $0.event.element! }
 	}

--- a/Source/RxSwift/not.swift
+++ b/Source/RxSwift/not.swift
@@ -9,7 +9,7 @@
 import Foundation
 import RxSwift
 
-extension ObservableType where E == Bool {
+extension ObservableType where Element == Bool {
     /// Boolean not operator
     public func not() -> Observable<Bool> {
         return self.map(!)

--- a/Source/RxSwift/nwise.swift
+++ b/Source/RxSwift/nwise.swift
@@ -27,7 +27,7 @@ extension ObservableType {
 
      - parameter n: size of the groups, must be greater than 1
     */
-    public func nwise(_ n: Int) -> Observable<[E]> {
+    public func nwise(_ n: Int) -> Observable<[Element]> {
         assert(n > 1, "n must be greater than 1")
         return self
             .scan([]) { acc, item in Array((acc + [item]).suffix(n)) }
@@ -50,7 +50,7 @@ extension ObservableType {
           v
          -------(1,2)-(2,3)----(3,4)-----(4,5)----->
     */
-    public func pairwise() -> Observable<(E, E)> {
+    public func pairwise() -> Observable<(Element, Element)> {
         return self.nwise(2)
             .map { ($0[0], $0[1]) }
     }

--- a/Source/RxSwift/once.swift
+++ b/Source/RxSwift/once.swift
@@ -24,7 +24,7 @@ extension Observable {
 	 - returns: An observable sequence containing the single specified element delivered once.
 	*/
 
-	public static func once(_ element: E) -> Observable<E> {
+	public static func once(_ element: Element) -> Observable<Element> {
 		var delivered: UInt32 = 0
 		return create { observer in
 			let wasDelivered = OSAtomicOr32OrigBarrier(1, &delivered)

--- a/Source/RxSwift/partition.swift
+++ b/Source/RxSwift/partition.swift
@@ -3,7 +3,7 @@
 //  RxSwiftExt
 //
 //  Created by Shai Mishali on 24/11/2018.
-//  Copyright © 2018 RxSwiftCommunity. All rights reserved.
+//  Copyright © 2018 RxSwift Community. All rights reserved.
 //
 
 import RxSwift
@@ -16,8 +16,8 @@ public extension ObservableType {
 
      - returns: A tuple of two streams of elements that match, and don't match, the provided predicate.
     */
-    func partition(_ predicate: @escaping (E) throws -> Bool) -> (matches: Observable<E>, nonMatches: Observable<E>) {
-        let stream = self.map{ ($0, try predicate($0)) }.share()
+    func partition(_ predicate: @escaping (Element) throws -> Bool) -> (matches: Observable<Element>, nonMatches: Observable<Element>) {
+        let stream = self.map { ($0, try predicate($0)) }.share()
 
         let hits = stream.filter { $0.1 }.map { $0.0 }
         let misses = stream.filter { !$0.1 }.map { $0.0 }

--- a/Source/RxSwift/pausable.swift
+++ b/Source/RxSwift/pausable.swift
@@ -21,7 +21,7 @@ extension ObservableType {
 	- returns: The observable sequence which is paused based upon the pauser observable sequence.
 	*/
 
-    public func pausable<P: ObservableType> (_ pauser: P) -> Observable<E> where P.E == Bool {
+    public func pausable<P: ObservableType> (_ pauser: P) -> Observable<Element> where P.Element == Bool {
 		return withLatestFrom(pauser) { element, paused in
 				(element, paused)
 			}

--- a/Source/RxSwift/pausableBuffered.swift
+++ b/Source/RxSwift/pausableBuffered.swift
@@ -26,10 +26,10 @@ extension ObservableType {
      - parameter flushOnError: If `true` bufered elements will be flushed when the source errors. Default `true`.
      - returns: The observable sequence which is paused and resumed based upon the pauser observable sequence.
      */
-    public func pausableBuffered<P: ObservableType> (_ pauser: P, limit: Int? = 1, flushOnCompleted: Bool = true, flushOnError: Bool = true) -> Observable<E> where P.E == Bool {
+    public func pausableBuffered<P: ObservableType> (_ pauser: P, limit: Int? = 1, flushOnCompleted: Bool = true, flushOnError: Bool = true) -> Observable<Element> where P.Element == Bool {
 
-        return Observable<E>.create { observer in
-            var buffer: [E] = []
+        return Observable<Element>.create { observer in
+            var buffer: [Element] = []
             if let limit = limit {
                 buffer.reserveCapacity(limit)
             }

--- a/Source/RxSwift/repeatWithBehavior.swift
+++ b/Source/RxSwift/repeatWithBehavior.swift
@@ -29,7 +29,7 @@ extension ObservableType {
 	- parameter shouldRepeat: Custom optional closure for decided whether the observable should repeat another round
 	- returns: Observable sequence that will be automatically repeat when it completes
 	*/
-	public func repeatWithBehavior(_ behavior: RepeatBehavior, scheduler: SchedulerType = MainScheduler.instance, shouldRepeat: RepeatPredicate? = nil) -> Observable<E> {
+	public func repeatWithBehavior(_ behavior: RepeatBehavior, scheduler: SchedulerType = MainScheduler.instance, shouldRepeat: RepeatPredicate? = nil) -> Observable<Element> {
 		return repeatWithBehavior(1, behavior: behavior, scheduler: scheduler, shouldRepeat: shouldRepeat)
 	}
 
@@ -42,7 +42,7 @@ extension ObservableType {
 	- returns: Observable sequence that will be automatically repeat when it completes
 	*/
 	internal func repeatWithBehavior(_ currentRepeat: UInt, behavior: RepeatBehavior, scheduler: SchedulerType = MainScheduler.instance, shouldRepeat: RepeatPredicate? = nil)
-		-> Observable<E> {
+		-> Observable<Element> {
 			guard currentRepeat > 0 else { return Observable.empty() }
 
 			// calculate conditions for bahavior
@@ -63,7 +63,7 @@ extension ObservableType {
                         return Observable.empty()
                     }
 
-                    guard conditions.delay > 0.0 else {
+                    guard conditions.delay != .never else {
                         // if there is no delay, simply retry
                         return self.repeatWithBehavior(currentRepeat + 1, behavior: behavior, scheduler: scheduler, shouldRepeat: shouldRepeat)
                     }

--- a/Source/RxSwift/toSortedArray.swift
+++ b/Source/RxSwift/toSortedArray.swift
@@ -16,19 +16,19 @@ public extension ObservableType {
      - parameter by: A comparator closure to sort emitted elements.
      - returns: An observable sequence containing all the sorted emitted elements as an array.
     */
-    func toSortedArray(by: @escaping (E, E) -> Bool) -> Observable<[E]> {
+    func toSortedArray(by: @escaping (Element, Element) -> Bool) -> Single<[Element]> {
         return toArray().map { $0.sorted(by: by) }
     }
 }
 
-public extension ObservableType where E: Comparable {
+public extension ObservableType where Element: Comparable {
     /**
      Converts an Observable into another Observable that emits the whole sequence as a single sorted array and then terminates.
 
      - parameter ascending: Should the emitted items be ascending or descending.
      - returns: An observable sequence containing all the sorted emitted elements as an array.
     */
-    func toSortedArray(ascending: Bool = true) -> Observable<[E]> {
+    func toSortedArray(ascending: Bool = true) -> Single<[Element]> {
         return toSortedArray(by: { ascending ? $0 < $1 : $0 > $1 })
     }
 }

--- a/Source/RxSwift/unwrap.swift
+++ b/Source/RxSwift/unwrap.swift
@@ -17,7 +17,7 @@ extension ObservableType {
      - returns: An observable sequence of non-optional elements
      */
 
-    public func unwrap<T>() -> Observable<T> where E == T? {
+    public func unwrap<T>() -> Observable<T> where Element == T? {
         return self.filter { $0 != nil }.map { $0! }
     }
 }

--- a/Source/RxSwift/withUnretained.swift
+++ b/Source/RxSwift/withUnretained.swift
@@ -18,7 +18,7 @@ extension ObservableType {
      - returns: An observable sequence that contains the result of `resultSelector` being called with an unretained reference on `obj` and the values of the original sequence.
      */
     public func withUnretained<T: AnyObject, Out>(_ obj: T,
-                                                  resultSelector: @escaping ((T, Self.E)) -> Out) -> Observable<Out> {
+                                                  resultSelector: @escaping ((T, Element)) -> Out) -> Observable<Out> {
         return map { [weak obj] element -> Out in
             guard let obj = obj else { throw UnretainedError.failedRetaining }
 
@@ -41,7 +41,7 @@ extension ObservableType {
      - parameter obj: The object to provide an unretained reference on.
      - returns: An observable sequence of tuples that contains both an unretained reference on `obj` and the values of the original sequence.
      */
-    public func withUnretained<T: AnyObject>(_ obj: T) -> Observable<(T, Self.E)> {
+    public func withUnretained<T: AnyObject>(_ obj: T) -> Observable<(T, Element)> {
         return withUnretained(obj) { ($0, $1) }
     }
 }

--- a/Source/RxSwift/zipWith.swift
+++ b/Source/RxSwift/zipWith.swift
@@ -21,7 +21,7 @@ extension ObservableConvertibleType {
 
      - Returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
      */
-    public func zip<O2, ResultType>(with second: O2, resultSelector: @escaping (E, O2.E) throws -> ResultType) -> Observable<ResultType> where O2: ObservableConvertibleType {
+    public func zip<O2, ResultType>(with second: O2, resultSelector: @escaping (Element, O2.Element) throws -> ResultType) -> Observable<ResultType> where O2: ObservableConvertibleType {
         return Observable.zip(asObservable(), second.asObservable(), resultSelector: resultSelector)
     }
 }

--- a/Tests/RxCocoa/DistinctTests+RxCocoa.swift
+++ b/Tests/RxCocoa/DistinctTests+RxCocoa.swift
@@ -26,10 +26,10 @@ class DistinctCocoaTests: XCTestCase {
 
             scheduler.start()
 
-            let correct = [
-                next(0, DummyHashable(id: 1, name: "SomeName")),
-                completed(0)
-            ]
+            let correct = Recorded.events([
+                .next(0, DummyHashable(id: 1, name: "SomeName")),
+                .completed(0)
+            ])
 
             XCTAssertEqual(observer.events, correct)
         }
@@ -50,11 +50,11 @@ class DistinctCocoaTests: XCTestCase {
 
             scheduler.start()
 
-            let correct = [
-                next(0, DummyHashable(id: 1, name: "SomeName")),
-                next(0, DummyHashable(id: 2, name: "SomeName2")),
-                completed(0)
-            ]
+            let correct = Recorded.events([
+                .next(0, DummyHashable(id: 1, name: "SomeName")),
+                .next(0, DummyHashable(id: 2, name: "SomeName2")),
+                .completed(0)
+            ])
 
             XCTAssertEqual(observer.events, correct)
         }
@@ -73,7 +73,7 @@ class DistinctCocoaTests: XCTestCase {
             scheduler.start()
 
             let correct: [Recorded<Event<DummyHashable>>] = [
-                completed(0)
+                .completed(0)
             ]
 
             XCTAssertEqual(observer.events, correct)
@@ -84,19 +84,19 @@ class DistinctCocoaTests: XCTestCase {
         let scheduler = TestScheduler(initialClock: 0, simulateProcessingDelay: false)
 
         SharingScheduler.mock(scheduler: scheduler) {
-            let values = [DummyEquatable(id: 1, name: "SomeName")]
-            let value = DummyEquatable(id: 0, name: "NoneName")
-            let observer = scheduler.createObserver(DummyEquatable.self)
+            let values = [DummyHashable(id: 1, name: "SomeName")]
+            let value = DummyHashable(id: 0, name: "NoneName")
+            let observer = scheduler.createObserver(DummyHashable.self)
 
             _ = Observable.from(values).asDriver(onErrorJustReturn: value)
                 .distinct().drive(observer)
 
             scheduler.start()
 
-            let correct = [
-                next(0, DummyEquatable(id: 1, name: "SomeName")),
-                completed(0)
-            ]
+            let correct = Recorded.events([
+                .next(0, DummyHashable(id: 1, name: "SomeName")),
+                .completed(0)
+            ])
 
             XCTAssertEqual(observer.events, correct)
         }
@@ -106,22 +106,22 @@ class DistinctCocoaTests: XCTestCase {
         let scheduler = TestScheduler(initialClock: 0, simulateProcessingDelay: false)
 
         SharingScheduler.mock(scheduler: scheduler) {
-            let values = [DummyEquatable(id: 1, name: "SomeName"),
-                          DummyEquatable(id: 2, name: "SomeName2"),
-                          DummyEquatable(id: 1, name: "SomeName")]
+            let values = [DummyHashable(id: 1, name: "SomeName"),
+                          DummyHashable(id: 2, name: "SomeName2"),
+                          DummyHashable(id: 1, name: "SomeName")]
 
-            let errored = DummyEquatable(id: 0, name: "NoneName")
-            let observer = scheduler.createObserver(DummyEquatable.self)
+            let errored = DummyHashable(id: 0, name: "NoneName")
+            let observer = scheduler.createObserver(DummyHashable.self)
 
             _ = Observable.from(values).asDriver(onErrorJustReturn: errored).distinct().drive(observer)
 
             scheduler.start()
 
-            let correct = [
-                next(0, DummyEquatable(id: 1, name: "SomeName")),
-                next(0, DummyEquatable(id: 2, name: "SomeName2")),
-                completed(0)
-            ]
+            let correct = Recorded.events([
+                .next(0, DummyHashable(id: 1, name: "SomeName")),
+                .next(0, DummyHashable(id: 2, name: "SomeName2")),
+                .completed(0)
+            ])
 
             XCTAssertEqual(observer.events, correct)
         }
@@ -131,15 +131,15 @@ class DistinctCocoaTests: XCTestCase {
         let scheduler = TestScheduler(initialClock: 0, simulateProcessingDelay: false)
 
         SharingScheduler.mock(scheduler: scheduler) {
-            let errored = DummyEquatable(id: 0, name: "NoneName")
-            let observer = scheduler.createObserver(DummyEquatable.self)
+            let errored = DummyHashable(id: 0, name: "NoneName")
+            let observer = scheduler.createObserver(DummyHashable.self)
 
-            _ = Observable<DummyEquatable>.empty().asDriver(onErrorJustReturn: errored).distinct().drive(observer)
+            _ = Observable<DummyHashable>.empty().asDriver(onErrorJustReturn: errored).distinct().drive(observer)
 
             scheduler.start()
 
-            let correct: [Recorded<Event<DummyEquatable>>] = [
-                completed(0)
+            let correct: [Recorded<Event<DummyHashable>>] = [
+                .completed(0)
             ]
 
             XCTAssertEqual(observer.events, correct)
@@ -150,12 +150,12 @@ class DistinctCocoaTests: XCTestCase {
         let scheduler = TestScheduler(initialClock: 0, simulateProcessingDelay: false)
 
         SharingScheduler.mock(scheduler: scheduler) {
-            let values = [DummyEquatable(id: 1, name: "SomeName1"),
-                          DummyEquatable(id: 2, name: "SomeName2"),
-                          DummyEquatable(id: 3, name: "SomeName1")]
+            let values = [DummyHashable(id: 1, name: "SomeName1"),
+                          DummyHashable(id: 2, name: "SomeName2"),
+                          DummyHashable(id: 3, name: "SomeName1")]
 
-            let errored = DummyEquatable(id: 0, name: "SomeName0")
-            let observer = scheduler.createObserver(DummyEquatable.self)
+            let errored = DummyHashable(id: 0, name: "SomeName0")
+            let observer = scheduler.createObserver(DummyHashable.self)
 
             _ = Observable.from(values).asDriver(onErrorJustReturn: errored)
                 .distinct {
@@ -164,10 +164,10 @@ class DistinctCocoaTests: XCTestCase {
 
             scheduler.start()
 
-            let correct = [
-                next(0, DummyEquatable(id: 1, name: "SomeName1")),
-                completed(0)
-            ]
+            let correct = Recorded.events([
+                .next(0, DummyHashable(id: 1, name: "SomeName1")),
+                .completed(0)
+            ])
 
             XCTAssertEqual(observer.events, correct)
         }
@@ -177,12 +177,12 @@ class DistinctCocoaTests: XCTestCase {
         let scheduler = TestScheduler(initialClock: 0, simulateProcessingDelay: false)
 
         SharingScheduler.mock(scheduler: scheduler) {
-            let values = [DummyEquatable(id: 1, name: "SomeName1"),
-                          DummyEquatable(id: 2, name: "SomeName2"),
-                          DummyEquatable(id: 3, name: "SomeName3")]
+            let values = [DummyHashable(id: 1, name: "SomeName1"),
+                          DummyHashable(id: 2, name: "SomeName2"),
+                          DummyHashable(id: 3, name: "SomeName3")]
 
-            let errored = DummyEquatable(id: 0, name: "SomeName0")
-            let observer = scheduler.createObserver(DummyEquatable.self)
+            let errored = DummyHashable(id: 0, name: "SomeName0")
+            let observer = scheduler.createObserver(DummyHashable.self)
 
             _ = Observable.from(values).asDriver(onErrorJustReturn: errored)
                 .distinct {
@@ -191,12 +191,12 @@ class DistinctCocoaTests: XCTestCase {
 
             scheduler.start()
 
-            let correct = [
-                next(0, DummyEquatable(id: 1, name: "SomeName1")),
-                next(0, DummyEquatable(id: 2, name: "SomeName2")),
-                next(0, DummyEquatable(id: 3, name: "SomeName3")),
-                completed(0)
-            ]
+            let correct = Recorded.events([
+                .next(0, DummyHashable(id: 1, name: "SomeName1")),
+                .next(0, DummyHashable(id: 2, name: "SomeName2")),
+                .next(0, DummyHashable(id: 3, name: "SomeName3")),
+                .completed(0)
+            ])
 
             XCTAssertEqual(observer.events, correct)
         }
@@ -206,10 +206,10 @@ class DistinctCocoaTests: XCTestCase {
         let scheduler = TestScheduler(initialClock: 0, simulateProcessingDelay: false)
 
         SharingScheduler.mock(scheduler: scheduler) {
-            let errored = DummyEquatable(id: 0, name: "NoneName")
-            let observer = scheduler.createObserver(DummyEquatable.self)
+            let errored = DummyHashable(id: 0, name: "NoneName")
+            let observer = scheduler.createObserver(DummyHashable.self)
 
-            _ = Observable<DummyEquatable>.empty().asDriver(onErrorJustReturn: errored)
+            _ = Observable<DummyHashable>.empty().asDriver(onErrorJustReturn: errored)
                 .distinct {
                     $0.id < 0
                 }
@@ -217,8 +217,8 @@ class DistinctCocoaTests: XCTestCase {
 
             scheduler.start()
 
-            let correct: [Recorded<Event<DummyEquatable>>] = [
-                completed(0)
+            let correct: [Recorded<Event<DummyHashable>>] = [
+                .completed(0)
             ]
 
             XCTAssertEqual(observer.events, correct)
@@ -229,12 +229,12 @@ class DistinctCocoaTests: XCTestCase {
         let scheduler = TestScheduler(initialClock: 0, simulateProcessingDelay: false)
 
         SharingScheduler.mock(scheduler: scheduler) {
-            let values = [DummyEquatable(id: 1, name: "SomeName1"),
-                          DummyEquatable(id: 2, name: "SomeName2"),
-                          DummyEquatable(id: 3, name: "SomeName3")]
+            let values = [DummyHashable(id: 1, name: "SomeName1"),
+                          DummyHashable(id: 2, name: "SomeName2"),
+                          DummyHashable(id: 3, name: "SomeName3")]
 
-            let errored = DummyEquatable(id: 0, name: "NoneName")
-            let observer = scheduler.createObserver(DummyEquatable.self)
+            let errored = DummyHashable(id: 0, name: "NoneName")
+            let observer = scheduler.createObserver(DummyHashable.self)
 
             _ = Observable.from(values).asDriver(onErrorJustReturn: errored)
                 .distinct {
@@ -243,10 +243,10 @@ class DistinctCocoaTests: XCTestCase {
 
             scheduler.start()
 
-            let correct = [
-                next(0, DummyEquatable(id: 1, name: "SomeName1")),
-                completed(0)
-            ]
+            let correct = Recorded.events([
+                .next(0, DummyHashable(id: 1, name: "SomeName1")),
+                .completed(0)
+            ])
 
             XCTAssertEqual(observer.events, correct)
         }
@@ -256,12 +256,12 @@ class DistinctCocoaTests: XCTestCase {
         let scheduler = TestScheduler(initialClock: 0, simulateProcessingDelay: false)
 
         SharingScheduler.mock(scheduler: scheduler) {
-            let values = [DummyEquatable(id: 1, name: "SomeName1"),
-                          DummyEquatable(id: 2, name: "SomeName2"),
-                          DummyEquatable(id: 3, name: "SomeName3")]
+            let values = [DummyHashable(id: 1, name: "SomeName1"),
+                          DummyHashable(id: 2, name: "SomeName2"),
+                          DummyHashable(id: 3, name: "SomeName3")]
 
-            let errored = DummyEquatable(id: 0, name: "NoneName")
-            let observer = scheduler.createObserver(DummyEquatable.self)
+            let errored = DummyHashable(id: 0, name: "NoneName")
+            let observer = scheduler.createObserver(DummyHashable.self)
 
             _ = Observable.from(values).asDriver(onErrorJustReturn: errored)
                 .distinct {
@@ -270,11 +270,11 @@ class DistinctCocoaTests: XCTestCase {
 
             scheduler.start()
 
-            let correct = [
-                next(0, DummyEquatable(id: 1, name: "SomeName1")),
-                next(0, DummyEquatable(id: 2, name: "SomeName2")),
-                completed(0)
-            ]
+            let correct = Recorded.events([
+                .next(0, DummyHashable(id: 1, name: "SomeName1")),
+                .next(0, DummyHashable(id: 2, name: "SomeName2")),
+                .completed(0)
+            ])
 
             XCTAssertEqual(observer.events, correct)
         }

--- a/Tests/RxCocoa/MapToTests+RxCocoa.swift
+++ b/Tests/RxCocoa/MapToTests+RxCocoa.swift
@@ -40,12 +40,13 @@ class MapToCocoaTests: XCTestCase {
 
     func testReplaceWithResultValues() {
         // test elements values and type
-        let correctValues = [
-            next(0, "candy"),
-            next(0, "candy"),
-            next(0, "candy"),
-            completed(0)
-        ]
+        let correctValues = Recorded.events([
+            .next(0, "candy"),
+            .next(0, "candy"),
+            .next(0, "candy"),
+            .completed(0)
+        ])
+
         XCTAssertEqual(observer.events, correctValues)
     }
 }

--- a/Tests/RxCocoa/NotTests+RxCocoa.swift
+++ b/Tests/RxCocoa/NotTests+RxCocoa.swift
@@ -25,12 +25,12 @@ class NotCocoaTests: XCTestCase {
 
         scheduler.start()
 
-        let correct = [
-            next(0, false),
-            next(0, true),
-            next(0, false),
-            completed(0)
-        ]
+        let correct = Recorded.events([
+            .next(0, false),
+            .next(0, true),
+            .next(0, false),
+            .completed(0)
+        ])
 
         XCTAssertEqual(observer.events, correct)
     }

--- a/Tests/RxCocoa/PartitionTests+RxCocoa.swift
+++ b/Tests/RxCocoa/PartitionTests+RxCocoa.swift
@@ -3,7 +3,7 @@
 //  RxSwiftExt
 //
 //  Created by Shai Mishali on 24/11/2018.
-//  Copyright © 2018 RxSwiftCommunity. All rights reserved.
+//  Copyright © 2018 RxSwift Community. All rights reserved.
 //
 
 import Foundation

--- a/Tests/RxSwift/BufferWithTriggerTests.swift
+++ b/Tests/RxSwift/BufferWithTriggerTests.swift
@@ -1,9 +1,9 @@
 //
 //  BufferWithTriggerTests.swift
-//  RxSwiftExt-iOS
+//  RxSwiftExt
 //
 //  Created by Patrick Maltagliati on 11/12/18.
-//  Copyright © 2018 RxSwiftCommunity. All rights reserved.
+//  Copyright © 2018 RxSwift Community. All rights reserved.
 //
 
 import XCTest
@@ -19,23 +19,23 @@ class BufferWithTriggerTests: XCTestCase {
     func testBuffersUntilBoundaryEmits() {
         let underlying = scheduler.createHotObservable(
             [
-                next(150, 1),
-                next(201, 2),
-                next(230, 3),
-                next(300, 4),
-                next(350, 5),
-                next(375, 6),
-                next(400, 7),
-                next(430, 8),
-                completed(500)
+                .next(150, 1),
+                .next(201, 2),
+                .next(230, 3),
+                .next(300, 4),
+                .next(350, 5),
+                .next(375, 6),
+                .next(400, 7),
+                .next(430, 8),
+                .completed(500)
             ]
         )
 
         let boundary = scheduler.createHotObservable(
             [
-                next(201, ()),
-                next(301, ()),
-                next(401, ())
+                .next(201, ()),
+                .next(301, ()),
+                .next(401, ())
             ]
         )
 
@@ -43,13 +43,14 @@ class BufferWithTriggerTests: XCTestCase {
             underlying.bufferWithTrigger(boundary.asObservable())
         }
 
-        let expected = [
-            next(201, [2]),
-            next(301, [3, 4]),
-            next(401, [5, 6, 7]),
-            next(500, [8]),
-            completed(500)
-        ]
+        let expected = Recorded.events([
+            .next(201, [2]),
+            .next(301, [3, 4]),
+            .next(401, [5, 6, 7]),
+            .next(500, [8]),
+            .completed(500)
+        ])
+
         XCTAssertEqual(res.events, expected)
 
         XCTAssertEqual(underlying.subscriptions, [Subscription(200, 500)])
@@ -58,17 +59,17 @@ class BufferWithTriggerTests: XCTestCase {
     func testPausedError() {
         let underlying = scheduler.createHotObservable(
             [
-                next(150, 1),
-                next(210, 2),
-                error(230, testError),
-                completed(500)
+                .next(150, 1),
+                .next(210, 2),
+                .error(230, testError),
+                .completed(500)
             ]
         )
 
         let boundary = scheduler.createHotObservable(
             [
-                next(201, ()),
-                next(211, ())
+                .next(201, ()),
+                .next(211, ())
             ]
         )
 
@@ -76,11 +77,11 @@ class BufferWithTriggerTests: XCTestCase {
             underlying.bufferWithTrigger(boundary.asObservable())
         }
 
-        let expected = [
-            next(201, []),
-            next(211, [2]),
-            error(230, testError)
-        ]
+        let expected = Recorded.events([
+            .next(201, []),
+            .next(211, [2]),
+            .error(230, testError)
+        ])
         XCTAssertEqual(res.events, expected)
 
         XCTAssertEqual(underlying.subscriptions, [Subscription(200, 230)])

--- a/Tests/RxSwift/CountTests.swift
+++ b/Tests/RxSwift/CountTests.swift
@@ -1,9 +1,9 @@
 //
 //  CountTests.swift
-//  RxSwiftExt-iOS
+//  RxSwiftExt
 //
 //  Created by Fred on 06/11/2018.
-//  Copyright © 2018 RxSwiftCommunity. All rights reserved.
+//  Copyright © 2018 RxSwift Community. All rights reserved.
 //
 
 import XCTest
@@ -24,10 +24,10 @@ class CountTests: XCTestCase {
 
         scheduler.start()
 
-        let correct = [
-            next(0, 1),
-            completed(0)
-        ]
+        let correct = Recorded.events([
+            .next(0, 1),
+            .completed(0)
+        ])
 
         XCTAssertEqual(observer.events, correct)
     }
@@ -43,10 +43,10 @@ class CountTests: XCTestCase {
 
         scheduler.start()
 
-        let correct = [
-            next(0, 1),
-            completed(0)
-        ]
+        let correct = Recorded.events([
+            .next(0, 1),
+            .completed(0)
+        ])
 
         XCTAssertEqual(observer.events, correct)
     }
@@ -62,10 +62,10 @@ class CountTests: XCTestCase {
 
         scheduler.start()
 
-        let correct = [
-            next(0, 1),
-            completed(0)
-        ]
+        let correct = Recorded.events([
+            .next(0, 1),
+            .completed(0)
+        ])
 
         XCTAssertEqual(observer.events, correct)
     }
@@ -81,10 +81,10 @@ class CountTests: XCTestCase {
 
         scheduler.start()
 
-        let correct = [
-            next(0, 2),
-            completed(0)
-        ]
+        let correct = Recorded.events([
+            .next(0, 2),
+            .completed(0)
+        ])
 
         XCTAssertEqual(observer.events, correct)
     }
@@ -100,10 +100,10 @@ class CountTests: XCTestCase {
 
         scheduler.start()
 
-        let correct = [
-            next(0, 1),
-            completed(0)
-        ]
+        let correct = Recorded.events([
+            .next(0, 1),
+            .completed(0)
+        ])
 
         XCTAssertEqual(observer.events, correct)
     }
@@ -119,10 +119,10 @@ class CountTests: XCTestCase {
 
         scheduler.start()
 
-        let correct = [
-            next(0, 0),
-            completed(0)
-        ]
+        let correct = Recorded.events([
+            .next(0, 0),
+            .completed(0)
+        ])
 
         XCTAssertEqual(observer.events, correct)
     }
@@ -138,10 +138,10 @@ class CountTests: XCTestCase {
 
         scheduler.start()
 
-        let correct = [
-            next(0, 3),
-            completed(0)
-        ]
+        let correct = Recorded.events([
+            .next(0, 3),
+            .completed(0)
+        ])
 
         XCTAssertEqual(observer.events, correct)
     }
@@ -157,10 +157,10 @@ class CountTests: XCTestCase {
 
         scheduler.start()
 
-        let correct = [
-            next(0, 0),
-            completed(0)
-        ]
+        let correct = Recorded.events([
+            .next(0, 0),
+            .completed(0)
+        ])
 
         XCTAssertEqual(observer.events, correct)
     }
@@ -176,10 +176,10 @@ class CountTests: XCTestCase {
 
         scheduler.start()
 
-        let correct = [
-            next(0, 0),
-            completed(0)
-        ]
+        let correct = Recorded.events([
+            .next(0, 0),
+            .completed(0)
+        ])
 
         XCTAssertEqual(observer.events, correct)
     }
@@ -195,10 +195,10 @@ class CountTests: XCTestCase {
 
         scheduler.start()
 
-        let correct = [
-            next(0, 2),
-            completed(0)
-        ]
+        let correct = Recorded.events([
+            .next(0, 2),
+            .completed(0)
+        ])
 
         XCTAssertEqual(observer.events, correct)
     }
@@ -214,10 +214,10 @@ class CountTests: XCTestCase {
 
         scheduler.start()
 
-        let correct = [
-            next(0, 4),
-            completed(0)
-        ]
+        let correct = Recorded.events([
+            .next(0, 4),
+            .completed(0)
+        ])
 
         XCTAssertEqual(observer.events, correct)
     }

--- a/Tests/RxSwift/DistinctTests.swift
+++ b/Tests/RxSwift/DistinctTests.swift
@@ -14,19 +14,6 @@ import RxSwiftExt
 struct DummyHashable: Hashable {
     let id: Int
     let name: String
-
-    var hashValue: Int {
-        return id.hashValue ^ name.hashValue
-    }
-}
-
-struct DummyEquatable: Equatable {
-    let id: Int
-    let name: String
-}
-
-func == (lhs: DummyEquatable, rhs: DummyEquatable) -> Bool {
-    return (lhs.name == rhs.name) && (lhs.id == rhs.id)
 }
 
 func == (lhs: DummyHashable, rhs: DummyHashable) -> Bool {
@@ -45,10 +32,10 @@ class DistinctTests: XCTestCase {
 
         scheduler.start()
 
-        let correct = [
-            next(0, DummyHashable(id: 1, name: "SomeName")),
-            completed(0)
-        ]
+        let correct = Recorded.events([
+            .next(0, DummyHashable(id: 1, name: "SomeName")),
+            .completed(0)
+        ])
 
         XCTAssertEqual(observer.events, correct)
     }
@@ -66,11 +53,11 @@ class DistinctTests: XCTestCase {
 
         scheduler.start()
 
-        let correct = [
-            next(0, DummyHashable(id: 1, name: "SomeName")),
-            next(0, DummyHashable(id: 2, name: "SomeName2")),
-            completed(0)
-        ]
+        let correct = Recorded.events([
+            .next(0, DummyHashable(id: 1, name: "SomeName")),
+            .next(0, DummyHashable(id: 2, name: "SomeName2")),
+            .completed(0)
+        ])
 
         XCTAssertEqual(observer.events, correct)
     }
@@ -86,16 +73,16 @@ class DistinctTests: XCTestCase {
         scheduler.start()
 
         let correct: [Recorded<Event<DummyHashable>>] = [
-            completed(0)
+            .completed(0)
         ]
 
         XCTAssertEqual(observer.events, correct)
     }
 
     func testDistinctEquatableOne() {
-        let values = [DummyEquatable(id: 1, name: "SomeName")]
+        let values = [DummyHashable(id: 1, name: "SomeName")]
         let scheduler = TestScheduler(initialClock: 0)
-        let observer = scheduler.createObserver(DummyEquatable.self)
+        let observer = scheduler.createObserver(DummyHashable.self)
 
         _ = Observable.from(values)
             .distinct()
@@ -103,20 +90,20 @@ class DistinctTests: XCTestCase {
 
         scheduler.start()
 
-        let correct = [
-            next(0, DummyEquatable(id: 1, name: "SomeName")),
-            completed(0)
-        ]
+        let correct = Recorded.events([
+            .next(0, DummyHashable(id: 1, name: "SomeName")),
+            .completed(0)
+        ])
 
         XCTAssertEqual(observer.events, correct)
     }
 
     func testDistinctEquatableTwo() {
-        let values = [DummyEquatable(id: 1, name: "SomeName"),
-                      DummyEquatable(id: 2, name: "SomeName2"),
-                      DummyEquatable(id: 1, name: "SomeName")]
+        let values = [DummyHashable(id: 1, name: "SomeName"),
+                      DummyHashable(id: 2, name: "SomeName2"),
+                      DummyHashable(id: 1, name: "SomeName")]
         let scheduler = TestScheduler(initialClock: 0)
-        let observer = scheduler.createObserver(DummyEquatable.self)
+        let observer = scheduler.createObserver(DummyHashable.self)
 
         _ = Observable.from(values)
             .distinct()
@@ -124,38 +111,38 @@ class DistinctTests: XCTestCase {
 
         scheduler.start()
 
-        let correct = [
-            next(0, DummyEquatable(id: 1, name: "SomeName")),
-            next(0, DummyEquatable(id: 2, name: "SomeName2")),
-            completed(0)
-        ]
+        let correct = Recorded.events([
+            .next(0, DummyHashable(id: 1, name: "SomeName")),
+            .next(0, DummyHashable(id: 2, name: "SomeName2")),
+            .completed(0)
+        ])
 
         XCTAssertEqual(observer.events, correct)
     }
 
     func testDistinctEquatableEmpty() {
         let scheduler = TestScheduler(initialClock: 0)
-        let observer = scheduler.createObserver(DummyEquatable.self)
+        let observer = scheduler.createObserver(DummyHashable.self)
 
-        _ = Observable<DummyEquatable>.empty()
+        _ = Observable<DummyHashable>.empty()
             .distinct()
             .subscribe(observer)
 
         scheduler.start()
 
-        let correct: [Recorded<Event<DummyEquatable>>] = [
-            completed(0)
+        let correct: [Recorded<Event<DummyHashable>>] = [
+            .completed(0)
         ]
 
         XCTAssertEqual(observer.events, correct)
     }
 
     func testDistinctPredicateOne() {
-        let values = [DummyEquatable(id: 1, name: "SomeName1"),
-                      DummyEquatable(id: 2, name: "SomeName2"),
-                      DummyEquatable(id: 3, name: "SomeName1")]
+        let values = [DummyHashable(id: 1, name: "SomeName1"),
+                      DummyHashable(id: 2, name: "SomeName2"),
+                      DummyHashable(id: 3, name: "SomeName1")]
         let scheduler = TestScheduler(initialClock: 0)
-        let observer = scheduler.createObserver(DummyEquatable.self)
+        let observer = scheduler.createObserver(DummyHashable.self)
 
 		_ = Observable.from(values)
 			.distinct {
@@ -164,20 +151,20 @@ class DistinctTests: XCTestCase {
 
         scheduler.start()
 
-        let correct = [
-            next(0, DummyEquatable(id: 1, name: "SomeName1")),
-            completed(0)
-        ]
+        let correct = Recorded.events([
+            .next(0, DummyHashable(id: 1, name: "SomeName1")),
+            .completed(0)
+        ])
 
         XCTAssertEqual(observer.events, correct)
     }
 
     func testDistinctPredicateAll() {
-        let values = [DummyEquatable(id: 1, name: "SomeName1"),
-                      DummyEquatable(id: 2, name: "SomeName2"),
-                      DummyEquatable(id: 3, name: "SomeName3")]
+        let values = [DummyHashable(id: 1, name: "SomeName1"),
+                      DummyHashable(id: 2, name: "SomeName2"),
+                      DummyHashable(id: 3, name: "SomeName3")]
         let scheduler = TestScheduler(initialClock: 0)
-        let observer = scheduler.createObserver(DummyEquatable.self)
+        let observer = scheduler.createObserver(DummyHashable.self)
 
 		_ = Observable.from(values)
 			.distinct {
@@ -186,21 +173,21 @@ class DistinctTests: XCTestCase {
 
         scheduler.start()
 
-        let correct = [
-            next(0, DummyEquatable(id: 1, name: "SomeName1")),
-            next(0, DummyEquatable(id: 2, name: "SomeName2")),
-            next(0, DummyEquatable(id: 3, name: "SomeName3")),
-            completed(0)
-        ]
+        let correct = Recorded.events([
+            .next(0, DummyHashable(id: 1, name: "SomeName1")),
+            .next(0, DummyHashable(id: 2, name: "SomeName2")),
+            .next(0, DummyHashable(id: 3, name: "SomeName3")),
+            .completed(0)
+        ])
 
         XCTAssertEqual(observer.events, correct)
     }
 
     func testDistinctPredicateEmpty() {
         let scheduler = TestScheduler(initialClock: 0)
-        let observer = scheduler.createObserver(DummyEquatable.self)
+        let observer = scheduler.createObserver(DummyHashable.self)
 
-		_ = Observable<DummyEquatable>.empty()
+		_ = Observable<DummyHashable>.empty()
             .distinct {
                 $0.id < 0
             }
@@ -208,19 +195,19 @@ class DistinctTests: XCTestCase {
 
         scheduler.start()
 
-        let correct: [Recorded<Event<DummyEquatable>>] = [
-            completed(0)
+        let correct: [Recorded<Event<DummyHashable>>] = [
+            .completed(0)
         ]
 
         XCTAssertEqual(observer.events, correct)
     }
 
     func testDistinctPredicateFirst() {
-        let values = [DummyEquatable(id: 1, name: "SomeName1"),
-                      DummyEquatable(id: 2, name: "SomeName2"),
-                      DummyEquatable(id: 3, name: "SomeName3")]
+        let values = [DummyHashable(id: 1, name: "SomeName1"),
+                      DummyHashable(id: 2, name: "SomeName2"),
+                      DummyHashable(id: 3, name: "SomeName3")]
         let scheduler = TestScheduler(initialClock: 0)
-        let observer = scheduler.createObserver(DummyEquatable.self)
+        let observer = scheduler.createObserver(DummyHashable.self)
 
 		_ = Observable.from(values)
 			.distinct {
@@ -229,20 +216,20 @@ class DistinctTests: XCTestCase {
 
         scheduler.start()
 
-        let correct = [
-            next(0, DummyEquatable(id: 1, name: "SomeName1")),
-            completed(0)
-        ]
+        let correct = Recorded.events([
+            .next(0, DummyHashable(id: 1, name: "SomeName1")),
+            .completed(0)
+        ])
 
         XCTAssertEqual(observer.events, correct)
     }
 
     func testDistinctPredicateTwo() {
-        let values = [DummyEquatable(id: 1, name: "SomeName1"),
-                      DummyEquatable(id: 2, name: "SomeName2"),
-                      DummyEquatable(id: 3, name: "SomeName3")]
+        let values = [DummyHashable(id: 1, name: "SomeName1"),
+                      DummyHashable(id: 2, name: "SomeName2"),
+                      DummyHashable(id: 3, name: "SomeName3")]
         let scheduler = TestScheduler(initialClock: 0)
-        let observer = scheduler.createObserver(DummyEquatable.self)
+        let observer = scheduler.createObserver(DummyHashable.self)
 
 		_ = Observable.from(values)
 			.distinct {
@@ -251,11 +238,11 @@ class DistinctTests: XCTestCase {
 
         scheduler.start()
 
-        let correct = [
-            next(0, DummyEquatable(id: 1, name: "SomeName1")),
-            next(0, DummyEquatable(id: 2, name: "SomeName2")),
-            completed(0)
-        ]
+        let correct = Recorded.events([
+            .next(0, DummyHashable(id: 1, name: "SomeName1")),
+            .next(0, DummyHashable(id: 2, name: "SomeName2")),
+            .completed(0)
+        ])
 
         XCTAssertEqual(observer.events, correct)
     }

--- a/Tests/RxSwift/IgnoreTests.swift
+++ b/Tests/RxSwift/IgnoreTests.swift
@@ -7,9 +7,8 @@
 //
 
 import XCTest
-
-import RxSwift
 import RxSwiftExt
+import RxSwift
 import RxTest
 
 class IgnoreTests: XCTestCase {
@@ -24,11 +23,11 @@ class IgnoreTests: XCTestCase {
 
         scheduler.start()
 
-        let correct = [
-            next(0, "Hello"),
-            next(0, "world"),
-            completed(0)
-        ]
+        let correct = Recorded.events([
+            .next(0, "Hello"),
+            .next(0, "world"),
+            .completed(0)
+        ])
 
         XCTAssertEqual(observer.events, correct)
     }
@@ -44,17 +43,17 @@ class IgnoreTests: XCTestCase {
 
         scheduler.start()
 
-        let correct = [
-            next(0, 1),
-            next(0, 2),
-            next(0, 4),
-            next(0, 5),
-            next(0, 1),
-            next(0, 5),
-            next(0, 7),
-            next(0, 9),
-            completed(0)
-        ]
+        let correct = Recorded.events([
+            .next(0, 1),
+            .next(0, 2),
+            .next(0, 4),
+            .next(0, 5),
+            .next(0, 1),
+            .next(0, 5),
+            .next(0, 7),
+            .next(0, 9),
+            .completed(0)
+        ])
 
         XCTAssertEqual(observer.events, correct)
     }
@@ -70,14 +69,14 @@ class IgnoreTests: XCTestCase {
 
         scheduler.start()
 
-        let correct = [
-            next(0, 2),
-            next(0, 4),
-            next(0, 5),
-            next(0, 5),
-            next(0, 7),
-            completed(0)
-        ]
+        let correct = Recorded.events([
+            .next(0, 2),
+            .next(0, 4),
+            .next(0, 5),
+            .next(0, 5),
+            .next(0, 7),
+            .completed(0)
+        ])
 
         XCTAssertEqual(observer.events, correct)
     }
@@ -95,14 +94,14 @@ class IgnoreTests: XCTestCase {
 
         scheduler.start()
 
-        let correct = [
-            next(0, 2),
-            next(0, 4),
-            next(0, 5),
-            next(0, 5),
-            next(0, 7),
-            completed(0)
-        ]
+        let correct = Recorded.events([
+            .next(0, 2),
+            .next(0, 4),
+            .next(0, 5),
+            .next(0, 5),
+            .next(0, 7),
+            .completed(0)
+        ])
 
         XCTAssertEqual(observer.events, correct)
     }
@@ -120,14 +119,14 @@ class IgnoreTests: XCTestCase {
 
         scheduler.start()
 
-        let correct = [
-            next(0, 2),
-            next(0, 4),
-            next(0, 5),
-            next(0, 5),
-            next(0, 7),
-            completed(0)
-        ]
+        let correct = Recorded.events([
+            .next(0, 2),
+            .next(0, 4),
+            .next(0, 5),
+            .next(0, 5),
+            .next(0, 7),
+            .completed(0)
+        ])
 
         XCTAssertEqual(observer.events, correct)
     }
@@ -145,19 +144,19 @@ class IgnoreTests: XCTestCase {
 
         scheduler.start()
 
-        let correct = [
-            next(0, 1),
-            next(0, 2),
-            next(0, 3),
-            next(0, 4),
-            next(0, 5),
-            next(0, 1),
-            next(0, 3),
-            next(0, 5),
-            next(0, 7),
-            next(0, 9),
-            completed(0)
-        ]
+        let correct = Recorded.events([
+            .next(0, 1),
+            .next(0, 2),
+            .next(0, 3),
+            .next(0, 4),
+            .next(0, 5),
+            .next(0, 1),
+            .next(0, 3),
+            .next(0, 5),
+            .next(0, 7),
+            .next(0, 9),
+            .completed(0)
+        ])
 
         XCTAssertEqual(observer.events, correct)
     }

--- a/Tests/RxSwift/MapAtTests.swift
+++ b/Tests/RxSwift/MapAtTests.swift
@@ -45,12 +45,13 @@ class MapAtTests: XCTestCase {
 
     func testResultSequenceHasValuesAtProvidedKeypath() {
         // test elements values and type
-        let correctValues = [
-            next(0, "Bart"),
-            next(0, "Lisa"),
-            next(0, "Maggie"),
-            completed(0)
-        ]
+        let correctValues = Recorded.events([
+            .next(0, "Bart"),
+            .next(0, "Lisa"),
+            .next(0, "Maggie"),
+            .completed(0)
+        ])
+
         XCTAssertEqual(observer.events, correctValues)
     }
 }

--- a/Tests/RxSwift/MapManyTests.swift
+++ b/Tests/RxSwift/MapManyTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import RxSwiftExt
 import RxSwift
 import RxTest
 
@@ -33,10 +34,10 @@ class MapManyTests: XCTestCase {
         let sourceArray = Observable.of(1...4)
 
         let observer = runAndObserve(sourceArray.mapMany(SomeModel.init))
-        let correct = [
-            next(0, [SomeModel(1), SomeModel(2), SomeModel(3), SomeModel(4)]),
-            completed(0)
-        ]
+        let correct = Recorded.events([
+            .next(0, [SomeModel(1), SomeModel(2), SomeModel(3), SomeModel(4)]),
+            .completed(0)
+        ])
 
         XCTAssertEqual(observer.events.description, correct.description)
     }
@@ -45,10 +46,10 @@ class MapManyTests: XCTestCase {
         let sourceArray = Observable.of(1...10)
 
         let observer = runAndObserve(sourceArray.mapMany { $0 + 1 })
-        let correct = [
-            next(0, [2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
-            completed(0)
-        ]
+        let correct = Recorded.events([
+            .next(0, [2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
+            .completed(0)
+        ])
 
         XCTAssertEqual(observer.events, correct)
     }
@@ -57,10 +58,10 @@ class MapManyTests: XCTestCase {
         let sourceArray = Observable.just(["a", "b", "C"])
 
         let observer = runAndObserve(sourceArray.mapMany { ($0 + "x").lowercased() })
-        let correct = [
-            next(0, ["ax", "bx", "cx"]),
-            completed(0)
-        ]
+        let correct = Recorded.events([
+            .next(0, ["ax", "bx", "cx"]),
+            .completed(0)
+        ])
 
         XCTAssertEqual(observer.events, correct)
     }

--- a/Tests/RxSwift/Observable+OfTypeTests.swift
+++ b/Tests/RxSwift/Observable+OfTypeTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import RxSwiftExt
 import RxSwift
 import RxTest
 
@@ -24,28 +25,30 @@ extension ObservableOfTypeTest {
     func test_ofTypeComplete() {
         let scheduler = TestScheduler(initialClock: 0)
 
-        let xs = scheduler.createHotObservable([
-            next(110, NSNumber(value: 1)),
-            next(180, NSDecimalNumber(string: "2") as NSNumber),
-            next(230, NSNumber(value: 3)),
-            next(270, NSNumber(value: 4)),
-            next(340, NSDecimalNumber(string: "5") as NSNumber),
-            next(380, NSDecimalNumber(string: "6") as NSNumber),
-            completed(400),
-            next(410, NSDecimalNumber(string: "7") as NSNumber),
-            next(420, NSNumber(value: 8)),
-            error(430, testError),
-            completed(440)
+        let events: [Recorded<Event<NSNumber>>] = Recorded<Event<NSNumber>>.events([
+            .next(110, NSNumber(value: 1)),
+            .next(180, NSDecimalNumber(string: "2") as NSNumber),
+            .next(230, NSNumber(value: 3)),
+            .next(270, NSNumber(value: 4)),
+            .next(340, NSDecimalNumber(string: "5") as NSNumber),
+            .next(380, NSDecimalNumber(string: "6") as NSNumber),
+            .completed(400),
+            .next(410, NSDecimalNumber(string: "7") as NSNumber),
+            .next(420, NSNumber(value: 8)),
+            .error(430, testError),
+            .completed(440)
         ])
+
+        let xs = scheduler.createHotObservable(events)
 
         let res = scheduler.start { () -> Observable<NSDecimalNumber> in
             return xs.ofType(NSDecimalNumber.self)
         }
 
         XCTAssertEqual(res.events, [
-            next(340, NSDecimalNumber(string: "5")),
-            next(380, NSDecimalNumber(string: "6")),
-            completed(400)
+            .next(340, NSDecimalNumber(string: "5")),
+            .next(380, NSDecimalNumber(string: "6")),
+            .completed(400)
         ])
 
         XCTAssertEqual(xs.subscriptions, [
@@ -56,30 +59,32 @@ extension ObservableOfTypeTest {
     func test_ofTypeDowncastComplete() {
         let scheduler = TestScheduler(initialClock: 0)
 
-        let xs: TestableObservable<NSNumber> = scheduler.createHotObservable([
-            next(110, NSNumber(value: 1)),
-            next(180, NSDecimalNumber(string: "2") as NSNumber),
-            next(230, NSNumber(value: 3)),
-            next(270, NSNumber(value: 4)),
-            next(340, NSDecimalNumber(string: "5") as NSNumber),
-            next(380, NSDecimalNumber(string: "6") as NSNumber),
-            completed(400),
-            next(410, NSDecimalNumber(string: "7") as NSNumber),
-            next(420, NSNumber(value: 8)),
-            error(430, testError),
-            completed(440)
+        let events: [Recorded<Event<NSNumber>>] = Recorded<Event<NSNumber>>.events([
+            .next(110, NSNumber(value: 1)),
+            .next(180, NSDecimalNumber(string: "2") as NSNumber),
+            .next(230, NSNumber(value: 3)),
+            .next(270, NSNumber(value: 4)),
+            .next(340, NSDecimalNumber(string: "5") as NSNumber),
+            .next(380, NSDecimalNumber(string: "6") as NSNumber),
+            .completed(400),
+            .next(410, NSDecimalNumber(string: "7") as NSNumber),
+            .next(420, NSNumber(value: 8)),
+            .error(430, testError),
+            .completed(440)
         ])
+
+        let xs: TestableObservable<NSNumber> = scheduler.createHotObservable(events)
 
         let res = scheduler.start { () -> Observable<NSNumber> in
             return xs.ofType(NSNumber.self)
         }
 
         XCTAssertEqual(res.events, [
-            next(230, NSNumber(value: 3)),
-            next(270, NSNumber(value: 4)),
-            next(340, NSDecimalNumber(string: "5")),
-            next(380, NSDecimalNumber(string: "6")),
-            completed(400)
+            .next(230, NSNumber(value: 3)),
+            .next(270, NSNumber(value: 4)),
+            .next(340, NSDecimalNumber(string: "5")),
+            .next(380, NSDecimalNumber(string: "6")),
+            .completed(400)
         ])
 
         XCTAssertEqual(xs.subscriptions, [
@@ -90,25 +95,27 @@ extension ObservableOfTypeTest {
     func test_ofTypeNoInstanceComplete() {
         let scheduler = TestScheduler(initialClock: 0)
 
-        let xs: TestableObservable<NSNumber> = scheduler.createHotObservable([
-            next(110, NSNumber(value: 1)),
-            next(180, NSDecimalNumber(string: "2") as NSNumber),
-            next(230, NSNumber(value: 3)),
-            next(270, NSNumber(value: 4)),
-            next(340, NSDecimalNumber(string: "5") as NSNumber),
-            next(380, NSDecimalNumber(string: "6") as NSNumber),
-            completed(400),
-            next(410, NSDecimalNumber(string: "7") as NSNumber),
-            next(420, NSNumber(value: 8)),
-            error(430, testError),
-            completed(440)
+        let events: [Recorded<Event<NSNumber>>] = Recorded<Event<NSNumber>>.events([
+            .next(110, NSNumber(value: 1)),
+            .next(180, NSDecimalNumber(string: "2") as NSNumber),
+            .next(230, NSNumber(value: 3)),
+            .next(270, NSNumber(value: 4)),
+            .next(340, NSDecimalNumber(string: "5") as NSNumber),
+            .next(380, NSDecimalNumber(string: "6") as NSNumber),
+            .completed(400),
+            .next(410, NSDecimalNumber(string: "7") as NSNumber),
+            .next(420, NSNumber(value: 8)),
+            .error(430, testError),
+            .completed(440)
         ])
+
+        let xs: TestableObservable<NSNumber> = scheduler.createHotObservable(events)
 
         let res = scheduler.start { () -> Observable<String> in
             return xs.ofType(String.self)
         }
 
-        XCTAssertEqual(res.events, [completed(400)])
+        XCTAssertEqual(res.events, [.completed(400)])
 
         XCTAssertEqual(xs.subscriptions, [
             Subscription(TestScheduler.Defaults.subscribed, 400)
@@ -118,29 +125,31 @@ extension ObservableOfTypeTest {
     func test_ofTypeDisposed() {
         let scheduler = TestScheduler(initialClock: 0)
 
-        let xs = scheduler.createHotObservable([
-            next(110, 1),
-            next(180, 2),
-            next(230, 3),
-            next(270, 4),
-            next(340, 5),
-            next(380, 6),
-            next(390, 7),
-            next(450, 8),
-            next(470, 9),
-            completed(500)
+        let events: [Recorded<Event<NSNumber>>] = Recorded<Event<NSNumber>>.events([
+            .next(110, 1),
+            .next(180, 2),
+            .next(230, 3),
+            .next(270, 4),
+            .next(340, 5),
+            .next(380, 6),
+            .next(390, 7),
+            .next(450, 8),
+            .next(470, 9),
+            .completed(500)
         ])
+
+        let xs = scheduler.createHotObservable(events)
 
         let res = scheduler.start(disposed: 400) { () -> Observable<Int> in
             return xs.ofType(Int.self)
         }
 
         XCTAssertEqual(res.events, [
-            next(230, 3),
-            next(270, 4),
-            next(340, 5),
-            next(380, 6),
-            next(390, 7)
+            .next(230, 3),
+            .next(270, 4),
+            .next(340, 5),
+            .next(380, 6),
+            .next(390, 7)
         ])
 
         XCTAssertEqual(xs.subscriptions, [

--- a/Tests/RxSwift/OnceTests.swift
+++ b/Tests/RxSwift/OnceTests.swift
@@ -25,13 +25,13 @@ class OnceTests: XCTestCase {
 
         scheduler.start()
 
-        let correct1 = [
-            next(0, "Hello"),
-            completed(0)
-        ]
+        let correct1 = Recorded.events([
+            .next(0, "Hello"),
+            .completed(0)
+        ])
 
         let correct2: [Recorded<Event<String>>] = [
-            completed(0)
+            .completed(0)
         ]
 
         XCTAssertEqual(observer1.events, correct1)
@@ -56,22 +56,22 @@ class OnceTests: XCTestCase {
 
         scheduler.start()
 
-        let correct1 = [
-            next(0, "Hello"),
-            completed(0)
-        ]
+        let correct1 = Recorded.events([
+            .next(0, "Hello"),
+            .completed(0)
+        ])
 
         let correct2: [Recorded<Event<String>>] = [
-            completed(0)
+            .completed(0)
         ]
 
-        let correct3 = [
-            next(0, "world"),
-            completed(0)
-        ]
+        let correct3 = Recorded.events([
+            .next(0, "world"),
+            .completed(0)
+        ])
 
         let correct4: [Recorded<Event<String>>] = [
-            completed(0)
+            .completed(0)
         ]
 
         XCTAssertEqual(observer1.events, correct1)

--- a/Tests/RxSwift/PartitionTests.swift
+++ b/Tests/RxSwift/PartitionTests.swift
@@ -3,7 +3,7 @@
 //  RxSwiftExt
 //
 //  Created by Shai Mishali on 24/11/2018.
-//  Copyright © 2018 RxSwiftCommunity. All rights reserved.
+//  Copyright © 2018 RxSwift Community. All rights reserved.
 //
 
 import Foundation

--- a/Tests/RxSwift/ToSortedArrayTests.swift
+++ b/Tests/RxSwift/ToSortedArrayTests.swift
@@ -21,31 +21,31 @@ class ToSortedArrayTests: XCTestCase {
 
     func testDefaultToSortedArray() {
         let source = Observable.of(1, 4, 6, 1, 7, 8)
-        let observer = runAndObserve(source.toSortedArray())
-        let correct = [
-            next(0, [1, 1, 4, 6, 7, 8]),
-            completed(0)
-        ]
+        let observer = runAndObserve(source.toSortedArray().asObservable())
+        let correct = Recorded.events([
+            .next(0, [1, 1, 4, 6, 7, 8]),
+            .completed(0)
+        ])
         XCTAssertEqual(observer.events, correct)
     }
 
     func testAscCase() {
         let source = Observable.of(1, 4, 6, 1, 7, 8)
-        let observer = runAndObserve(source.toSortedArray(ascending: true))
-        let correct = [
-            next(0, [1, 1, 4, 6, 7, 8]),
-            completed(0)
-        ]
+        let observer = runAndObserve(source.toSortedArray(ascending: true).asObservable())
+        let correct = Recorded.events([
+            .next(0, [1, 1, 4, 6, 7, 8]),
+            .completed(0)
+        ])
         XCTAssertEqual(observer.events, correct)
     }
 
     func testDescCase() {
         let source = Observable.of(1, 4, 6, 1, 7, 8)
-        let observer = runAndObserve(source.toSortedArray(ascending: false))
-        let correct = [
-            next(0, [8, 7, 6, 4, 1, 1]),
-            completed(0)
-        ]
+        let observer = runAndObserve(source.toSortedArray(ascending: false).asObservable())
+        let correct = Recorded.events([
+            .next(0, [8, 7, 6, 4, 1, 1]),
+            .completed(0)
+        ])
         XCTAssertEqual(observer.events, correct)
     }
 }

--- a/Tests/RxSwift/UnwrapTests.swift
+++ b/Tests/RxSwift/UnwrapTests.swift
@@ -39,12 +39,13 @@ class UnwrapTests: XCTestCase {
 
     func testUnwrapResultValues() {
         // test elements values and type
-        let correctValues = [
-            next(0, 1),
-            next(0, 3),
-            next(0, 4),
-            completed(0)
-        ]
+        let correctValues = Recorded.events([
+            .next(0, 1),
+            .next(0, 3),
+            .next(0, 4),
+            .completed(0)
+        ])
+
         XCTAssertEqual(observer.events, correctValues)
     }
 }

--- a/Tests/RxSwift/WithUnretainedTests.swift
+++ b/Tests/RxSwift/WithUnretainedTests.swift
@@ -26,7 +26,7 @@ class WithUnretainedTests: XCTestCase {
             .next(220, 3),
             .next(225, 5),
             .next(230, 8),
-            completed(250)
+            .completed(250)
         ])
 
         tupleValues = scheduler.createColdObservable([
@@ -35,7 +35,7 @@ class WithUnretainedTests: XCTestCase {
             .next(220, (3, "c")),
             .next(225, (5, "d")),
             .next(230, (8, "e")),
-            completed(250)
+            .completed(250)
         ])
     }
 
@@ -48,7 +48,7 @@ class WithUnretainedTests: XCTestCase {
             .next(420, "\(testClassId), 3"),
             .next(425, "\(testClassId), 5"),
             .next(430, "\(testClassId), 8"),
-            completed(450)
+            .completed(450)
         ]
 
         let res = scheduler.start {
@@ -78,7 +78,7 @@ class WithUnretainedTests: XCTestCase {
             .next(410, "\(testClassId), 1"),
             .next(415, "\(testClassId), 2"),
             .next(420, "\(testClassId), 3"),
-            completed(425)
+            .completed(425)
         ]
 
         let res = scheduler.start {
@@ -106,7 +106,7 @@ class WithUnretainedTests: XCTestCase {
             .next(420, "\(testClassId), 3, c"),
             .next(425, "\(testClassId), 5, d"),
             .next(430, "\(testClassId), 8, e"),
-            completed(450)
+            .completed(450)
         ]
 
         let res = scheduler.start {

--- a/Tests/RxSwift/ZipWithTest.swift
+++ b/Tests/RxSwift/ZipWithTest.swift
@@ -38,11 +38,12 @@ class ZipWithTest: XCTestCase {
             }
         }
 
-        let expected = [
-			next(200, Pair(first: 1, second: "a")),
-			next(200, Pair(first: 2, second: "b")),
-			completed(200)
-		]
+        let expected = Recorded.events([
+			.next(200, Pair(first: 1, second: "a")),
+			.next(200, Pair(first: 2, second: "b")),
+			.completed(200)
+		])
+
         XCTAssertEqual(res.events, expected)
     }
 
@@ -57,7 +58,7 @@ class ZipWithTest: XCTestCase {
             }
         }
 
-        let expected: [Recorded<Event<Pair<Int, Int>>>] = [completed(200)]
+        let expected: [Recorded<Event<Pair<Int, Int>>>] = [.completed(200)]
         XCTAssertEqual(res.events, expected)
     }
 
@@ -72,7 +73,7 @@ class ZipWithTest: XCTestCase {
             }
         }
 
-        let expected: [Recorded<Event<Pair<Int, Int>>>] = [error(200, ZipWithTestError.error)]
+        let expected: [Recorded<Event<Pair<Int, Int>>>] = [.error(200, ZipWithTestError.error)]
         XCTAssertEqual(res.events, expected)
     }
 
@@ -87,10 +88,10 @@ class ZipWithTest: XCTestCase {
             }
         }
 
-        let expected = [
-			next(200, Pair(first: 1, second: "a")),
-			completed(200)
-		]
+        let expected = Recorded.events([
+			.next(200, Pair(first: 1, second: "a")),
+			.completed(200)
+		])
         XCTAssertEqual(res.events, expected)
     }
 
@@ -105,10 +106,10 @@ class ZipWithTest: XCTestCase {
             }
         }
 
-        let expected = [
-			next(200, Pair(first: 1, second: 2)),
-			completed(200)
-		]
+        let expected = Recorded.events([
+			.next(200, Pair(first: 1, second: 2)),
+			.completed(200)
+		])
         XCTAssertEqual(res.events, expected)
     }
 }

--- a/Tests/RxSwift/andTests.swift
+++ b/Tests/RxSwift/andTests.swift
@@ -26,20 +26,22 @@ class AndTests: XCTestCase {
 	func testSingle_oneTrueValue() {
 		let source = Observable.just(true)
 		let observer = runAndObserve(source.and())
-		let correct = [
-			next(0, true),
-			completed(0)
-		]
+		let correct = Recorded.events([
+			.next(0, true),
+			.completed(0)
+		])
+
 		XCTAssertEqual(observer.events, correct)
 	}
 
 	func testSingle_oneFalseValue() {
 		let source = Observable.just(false)
 		let observer = runAndObserve(source.and())
-		let correct = [
-			next(0, false),
-			completed(0)
-		]
+		let correct = Recorded.events([
+			.next(0, false),
+			.completed(0)
+		])
+
 		XCTAssertEqual(observer.events, correct)
 	}
 
@@ -47,7 +49,7 @@ class AndTests: XCTestCase {
 		let source = Observable<Bool>.empty()
 		let observer = runAndObserve(source.and())
 		let correct: [Recorded<Event<Bool>>] = [
-			completed(0)
+			.completed(0)
 		]
 		XCTAssertEqual(observer.events, correct)
 	}
@@ -56,8 +58,8 @@ class AndTests: XCTestCase {
 		let source = Observable.of(true, false)
 		let observer = runAndObserve(source.and())
 		let correct: [Recorded<Event<Bool>>] = [
-			next(0, false),
-			completed(0)
+			.next(0, false),
+			.completed(0)
 		]
 		XCTAssertEqual(observer.events, correct)
 	}
@@ -66,8 +68,8 @@ class AndTests: XCTestCase {
 		let source = Observable.of(false, true)
 		let observer = runAndObserve(source.and())
 		let correct: [Recorded<Event<Bool>>] = [
-			next(0, false),
-			completed(0)
+			.next(0, false),
+			.completed(0)
 		]
 		XCTAssertEqual(observer.events, correct)
 	}
@@ -76,8 +78,8 @@ class AndTests: XCTestCase {
 		let source = Observable.of(true, true, true)
 		let observer = runAndObserve(source.and())
 		let correct: [Recorded<Event<Bool>>] = [
-			next(0, true),
-			completed(0)
+			.next(0, true),
+			.completed(0)
 		]
 		XCTAssertEqual(observer.events, correct)
 	}
@@ -86,8 +88,8 @@ class AndTests: XCTestCase {
 		let source = Observable.of(true, true, true, false, true, false, true)
 		let observer = runAndObserve(source.and())
 		let correct: [Recorded<Event<Bool>>] = [
-			next(0, false),
-			completed(0)
+			.next(0, false),
+			.completed(0)
 		]
 		XCTAssertEqual(observer.events, correct)
 	}
@@ -96,7 +98,7 @@ class AndTests: XCTestCase {
 		let source = Observable<Bool>.error(AndTestsError.anyError)
 		let observer = runAndObserve(source.and())
 		let correct: [Recorded<Event<Bool>>] = [
-			error(0, AndTestsError.anyError)
+			.error(0, AndTestsError.anyError)
 		]
 		XCTAssertEqual(observer.events, correct)
 	}
@@ -104,11 +106,11 @@ class AndTests: XCTestCase {
 	func testSingle_multipleValuesWithFalseThenError() {
 		let scheduler = TestScheduler(initialClock: 0)
 		let source = scheduler.createColdObservable([
-			next(100, true),
-			next(110, false),
-			next(120, true),
-			error(130, AndTestsError.anyError),
-			completed(300)
+			.next(100, true),
+			.next(110, false),
+			.next(120, true),
+			.error(130, AndTestsError.anyError),
+			.completed(300)
 			])
 
 		let observer = scheduler.createObserver(Bool.self)
@@ -116,8 +118,8 @@ class AndTests: XCTestCase {
 		scheduler.start()
 
 		let correct: [Recorded<Event<Bool>>] = [
-			next(110, false),
-			completed(110)
+			.next(110, false),
+			.completed(110)
 		]
 		XCTAssertEqual(observer.events, correct)
 	}
@@ -125,11 +127,11 @@ class AndTests: XCTestCase {
 	func testSingle_multipleTrueValuesThenError() {
 		let scheduler = TestScheduler(initialClock: 0)
 		let source = scheduler.createColdObservable([
-			next(100, true),
-			next(110, true),
-			next(120, true),
-			error(130, AndTestsError.anyError),
-			completed(300)
+			.next(100, true),
+			.next(110, true),
+			.next(120, true),
+			.error(130, AndTestsError.anyError),
+			.completed(300)
 			])
 
 		let observer = scheduler.createObserver(Bool.self)
@@ -137,7 +139,7 @@ class AndTests: XCTestCase {
 		scheduler.start()
 
 		let correct: [Recorded<Event<Bool>>] = [
-			error(130, AndTestsError.anyError)
+			.error(130, AndTestsError.anyError)
 		]
 		XCTAssertEqual(observer.events, correct)
 	}
@@ -145,20 +147,21 @@ class AndTests: XCTestCase {
 	func testCollection_allTrue() {
 		let scheduler = TestScheduler(initialClock: 0)
 		let source1 = scheduler.createColdObservable([
-			next(100, true),
-			next(110, true),
-			next(120, true),
-			completed(130)
+			.next(100, true),
+			.next(110, true),
+			.next(120, true),
+			.completed(130)
 			])
 		let source2 = scheduler.createColdObservable([
-			next(50, true),
-			next(107, true),
-			completed(110)
+			.next(50, true),
+			.next(107, true),
+			.completed(110)
 			])
+
 		let source3 = scheduler.createColdObservable([
-			next(75, true),
-			next(299, true),
-			completed(300)
+			.next(75, true),
+			.next(299, true),
+			.completed(300)
 			])
 
 		let observer = scheduler.createObserver(Bool.self)
@@ -168,26 +171,26 @@ class AndTests: XCTestCase {
 			.subscribe(observer)
 		scheduler.start()
 
-		let correct = [
-			next(300, true),
-			completed(300)
-		]
+		let correct = Recorded.events([
+			.next(300, true),
+			.completed(300)
+		])
 		XCTAssertEqual(observer.events, correct)
 	}
 
 	func testCollection_trueAndEmpty() {
 		let scheduler = TestScheduler(initialClock: 0)
 		let source1 = scheduler.createColdObservable([
-			next(100, true),
-			next(120, true),
-			completed(130)
+			.next(100, true),
+			.next(120, true),
+			.completed(130)
 			])
 		let source2: TestableObservable<Bool> = scheduler.createColdObservable([
-			completed(110)
+			.completed(110)
 			])
 		let source3 = scheduler.createColdObservable([
-			next(75, true),
-			completed(300)
+			.next(75, true),
+			.completed(300)
 			])
 
 		let observer = scheduler.createObserver(Bool.self)
@@ -198,7 +201,7 @@ class AndTests: XCTestCase {
 		scheduler.start()
 
 		let correct: [Recorded<Event<Bool>>] = [
-			completed(300)
+			.completed(300)
 		]
 		XCTAssertEqual(observer.events, correct)
 	}
@@ -206,20 +209,20 @@ class AndTests: XCTestCase {
 	func testCollection_someFalse() {
 		let scheduler = TestScheduler(initialClock: 0)
 		let source1 = scheduler.createColdObservable([
-			next(100, true),
-			next(110, false),
-			next(120, true),
-			completed(130)
+			.next(100, true),
+			.next(110, false),
+			.next(120, true),
+			.completed(130)
 			])
 		let source2 = scheduler.createColdObservable([
-			next(50, true),
-			next(107, true),
-			completed(110)
+			.next(50, true),
+			.next(107, true),
+			.completed(110)
 			])
 		let source3 = scheduler.createColdObservable([
-			next(75, true),
-			next(299, true),
-			completed(300)
+			.next(75, true),
+			.next(299, true),
+			.completed(300)
 			])
 
 		let observer = scheduler.createObserver(Bool.self)
@@ -229,28 +232,28 @@ class AndTests: XCTestCase {
 			.subscribe(observer)
 		scheduler.start()
 
-		let correct = [
-			next(110, false),
-			completed(110)
-		]
+		let correct = Recorded.events([
+			.next(110, false),
+			.completed(110)
+		])
 		XCTAssertEqual(observer.events, correct)
 	}
 
 	func testCollection_someFalseAndEmpty() {
 		let scheduler = TestScheduler(initialClock: 0)
 		let source1 = scheduler.createColdObservable([
-			next(100, true),
-			next(120, false),
-			next(130, true),
-			completed(200)
+			.next(100, true),
+			.next(120, false),
+			.next(130, true),
+			.completed(200)
 			])
 		let source2: TestableObservable<Bool> = scheduler.createColdObservable([
-			completed(110)
+			.completed(110)
 			])
 		let source3 = scheduler.createColdObservable([
-			next(75, true),
-			next(299, true),
-			completed(300)
+			.next(75, true),
+			.next(299, true),
+			.completed(300)
 			])
 
 		let observer = scheduler.createObserver(Bool.self)
@@ -260,27 +263,27 @@ class AndTests: XCTestCase {
 			.subscribe(observer)
 		scheduler.start()
 
-		let correct = [
-			next(120, false),
-			completed(120)
-		]
+		let correct = Recorded.events([
+			.next(120, false),
+			.completed(120)
+		])
 		XCTAssertEqual(observer.events, correct)
 	}
 
 	func testCollection_falseAndEmptyAndError() {
 		let scheduler = TestScheduler(initialClock: 0)
 		let source1 = scheduler.createColdObservable([
-			next(100, true),
-			next(120, false),
-			next(130, true),
-			completed(200)
+			.next(100, true),
+			.next(120, false),
+			.next(130, true),
+			.completed(200)
 			])
 		let source2: TestableObservable<Bool> = scheduler.createColdObservable([
-			completed(110)
+			.completed(110)
 			])
 		let source3 = scheduler.createColdObservable([
-			next(75, true),
-			error(100, AndTestsError.anyError)
+			.next(75, true),
+			.error(100, AndTestsError.anyError)
 			])
 
 		let observer = scheduler.createObserver(Bool.self)
@@ -291,7 +294,7 @@ class AndTests: XCTestCase {
 		scheduler.start()
 
 		let correct: [Recorded<Event<Bool>>] = [
-			error(100, AndTestsError.anyError)
+			.error(100, AndTestsError.anyError)
 		]
 		XCTAssertEqual(observer.events, correct)
 	}

--- a/Tests/RxSwift/applyTests.swift
+++ b/Tests/RxSwift/applyTests.swift
@@ -29,7 +29,7 @@ class ApplyTests: XCTestCase {
             .filter { $0 > 0 }
             .map { $0 * $0 }
     }
-    
+
     private func transform(input: Single<Int>) -> Single<Int> {
         return input.map { $0 * $0 }
     }
@@ -46,34 +46,34 @@ class ApplyTests: XCTestCase {
 
         scheduler.start()
 
-        let correct = [
-            next(0, 42*42),
-            next(0, 100*100),
-            next(0, 1000*1000),
-            next(0, 1*1),
-            completed(0)
-        ]
+        let correct = Recorded.events([
+            .next(0, 42*42),
+            .next(0, 100*100),
+            .next(0, 1000*1000),
+            .next(0, 1*1),
+            .completed(0)
+        ])
 
         XCTAssertEqual(observer.events, correct)
     }
-    
+
     func testApplySingle() {
         let value = 10
         let scheduler = TestScheduler(initialClock: 0)
         let observer = scheduler.createObserver(Int.self)
-        
+
         _ = Single.just(value)
             .apply(transform)
             .asObservable()
             .subscribe(observer)
-        
+
         scheduler.start()
-        
-        let correct = [
-            next(0, 10*10),
-            completed(0)
-        ]
-        
+
+        let correct = Recorded.events([
+            .next(0, 10*10),
+            .completed(0)
+        ])
+
         XCTAssertEqual(observer.events, correct)
     }
 
@@ -82,11 +82,10 @@ class ApplyTests: XCTestCase {
             .distinctUntilChanged()
             .map { String(describing: $0) }
     }
-    
+
     func transformToString(input: Single<Int>) -> Single<String> {
         return input.map(String.init)
     }
-    
 
     func testApplyTransformingType() {
         let values = [0, 0, 42, 42, -7, 100, 1000, 1, 1]
@@ -100,37 +99,37 @@ class ApplyTests: XCTestCase {
 
         scheduler.start()
 
-        let correct = [
-            next(0, "0"),
-            next(0, "42"),
-            next(0, "-7"),
-            next(0, "100"),
-            next(0, "1000"),
-            next(0, "1"),
-            completed(0)
-        ]
+        let correct = Recorded.events([
+            .next(0, "0"),
+            .next(0, "42"),
+            .next(0, "-7"),
+            .next(0, "100"),
+            .next(0, "1000"),
+            .next(0, "1"),
+            .completed(0)
+        ])
 
         XCTAssertEqual(observer.events, correct)
     }
-    
+
     func testApplyTransformingTypeSingle() {
         let value = -7
-        
+
         let scheduler = TestScheduler(initialClock: 0)
         let observer = scheduler.createObserver(String.self)
-        
+
         _ = Single.just(value)
             .apply(transformToString)
             .asObservable()
             .subscribe(observer)
-        
+
         scheduler.start()
-        
-        let correct = [
-            next(0, "-7"),
-            completed(0)
-        ]
-        
+
+        let correct = Recorded.events([
+            .next(0, "-7"),
+            .completed(0)
+        ])
+
         XCTAssertEqual(observer.events, correct)
     }
 }

--- a/Tests/RxSwift/cascadeTests.swift
+++ b/Tests/RxSwift/cascadeTests.swift
@@ -33,10 +33,10 @@ class CascadeTests: XCTestCase {
 
     func testCascadeOne() {
         let xs = scheduler.createHotObservable([
-            next(110, 1),
-            next(180, 2),
-            next(230, 3),
-            completed(600)
+            .next(110, 1),
+            .next(180, 2),
+            .next(230, 3),
+            .completed(600)
         ])
 
         let res = scheduler.start { () -> Observable<Int> in
@@ -44,8 +44,8 @@ class CascadeTests: XCTestCase {
         }
 
         XCTAssertEqual(res.events, [
-            next(230, 3),
-            completed(600)
+            .next(230, 3),
+            .completed(600)
         ])
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 600)
@@ -54,33 +54,33 @@ class CascadeTests: XCTestCase {
 
     func testCascadeTwo() {
         let xs = scheduler.createHotObservable([
-            next(110, 1),
-            next(180, 2),
-            next(230, 3),
-            next(270, 4),
-            next(340, 5),
-            next(380, 6),
-            next(390, 7),
-            next(450, 8),
-            next(470, 9),
-            next(560, 10),
-            next(580, 11),
-            completed(600),
-            next(610, 12),
-            error(620, testError),
-            completed(630)
+            .next(110, 1),
+            .next(180, 2),
+            .next(230, 3),
+            .next(270, 4),
+            .next(340, 5),
+            .next(380, 6),
+            .next(390, 7),
+            .next(450, 8),
+            .next(470, 9),
+            .next(560, 10),
+            .next(580, 11),
+            .completed(600),
+            .next(610, 12),
+            .error(620, testError),
+            .completed(630)
             ])
 
         let ys = scheduler.createHotObservable([
-            next(350, 26),
-            next(390, 27),
-            next(450, 28),
-            next(470, 29),
-            next(560, 30),
-            completed(600),
-            next(610, 31),
-            error(620, testError),
-            completed(630)
+            .next(350, 26),
+            .next(390, 27),
+            .next(450, 28),
+            .next(470, 29),
+            .next(560, 30),
+            .completed(600),
+            .next(610, 31),
+            .error(620, testError),
+            .completed(630)
             ])
 
         let res = scheduler.start { () -> Observable<Int> in
@@ -88,15 +88,15 @@ class CascadeTests: XCTestCase {
         }
 
         XCTAssertEqual(res.events, [
-            next(230, 3),
-            next(270, 4),
-            next(340, 5),
-            next(350, 26),
-            next(390, 27),
-            next(450, 28),
-            next(470, 29),
-            next(560, 30),
-            completed(600)
+            .next(230, 3),
+            .next(270, 4),
+            .next(340, 5),
+            .next(350, 26),
+            .next(390, 27),
+            .next(450, 28),
+            .next(470, 29),
+            .next(560, 30),
+            .completed(600)
             ])
 
         XCTAssertEqual(xs.subscriptions, [
@@ -110,45 +110,45 @@ class CascadeTests: XCTestCase {
 
     func testCascadeSkipMiddleSequence() {
         let xs = scheduler.createHotObservable([
-            next(110, 1),
-            next(180, 2),
-            next(230, 3),
-            next(270, 4),
-            next(340, 5),
-            next(380, 6),
-            next(390, 7),
-            next(450, 8),
-            next(470, 9),
-            next(560, 10),
-            next(580, 11),
-            completed(600),
-            next(610, 12),
-            error(620, testError),
-            completed(630)
+            .next(110, 1),
+            .next(180, 2),
+            .next(230, 3),
+            .next(270, 4),
+            .next(340, 5),
+            .next(380, 6),
+            .next(390, 7),
+            .next(450, 8),
+            .next(470, 9),
+            .next(560, 10),
+            .next(580, 11),
+            .completed(600),
+            .next(610, 12),
+            .error(620, testError),
+            .completed(630)
             ])
 
         let ys = scheduler.createHotObservable([
-            next(350, 26),
-            next(390, 27),
-            next(450, 28),
-            next(470, 29),
-            next(560, 30),
-            completed(600),
-            next(610, 31),
-            error(620, testError),
-            completed(630)
+            .next(350, 26),
+            .next(390, 27),
+            .next(450, 28),
+            .next(470, 29),
+            .next(560, 30),
+            .completed(600),
+            .next(610, 31),
+            .error(620, testError),
+            .completed(630)
             ])
 
         let zs = scheduler.createHotObservable([
-            next(345, 126),
-            next(400, 127),
-            next(450, 128),
-            next(451, 129),
-            next(500, 130),
-            completed(600),
-            next(610, 31),
-            error(620, testError),
-            completed(630)
+            .next(345, 126),
+            .next(400, 127),
+            .next(450, 128),
+            .next(451, 129),
+            .next(500, 130),
+            .completed(600),
+            .next(610, 31),
+            .error(620, testError),
+            .completed(630)
             ])
 
         let res = scheduler.start { () -> Observable<Int> in
@@ -156,15 +156,15 @@ class CascadeTests: XCTestCase {
         }
 
         XCTAssertEqual(res.events, [
-            next(230, 3),
-            next(270, 4),
-            next(340, 5),
-            next(345, 126),
-            next(400, 127),
-            next(450, 128),
-            next(451, 129),
-            next(500, 130),
-            completed(600)
+            .next(230, 3),
+            .next(270, 4),
+            .next(340, 5),
+            .next(345, 126),
+            .next(400, 127),
+            .next(450, 128),
+            .next(451, 129),
+            .next(500, 130),
+            .completed(600)
             ])
 
         XCTAssertEqual(xs.subscriptions, [
@@ -182,21 +182,21 @@ class CascadeTests: XCTestCase {
 
     func testCascadeImmediateError() {
         let xs = scheduler.createHotObservable([
-            next(100, 1),
-            error(210, testError),
-            completed(630)
+            .next(100, 1),
+            .error(210, testError),
+            .completed(630)
             ])
 
         let ys = scheduler.createHotObservable([
-            next(350, 26),
-            next(390, 27),
-            next(450, 28),
-            next(470, 29),
-            next(560, 30),
-            completed(600),
-            next(610, 31),
-            error(620, testError),
-            completed(630)
+            .next(350, 26),
+            .next(390, 27),
+            .next(450, 28),
+            .next(470, 29),
+            .next(560, 30),
+            .completed(600),
+            .next(610, 31),
+            .error(620, testError),
+            .completed(630)
             ])
 
         let res = scheduler.start { () -> Observable<Int> in
@@ -204,7 +204,7 @@ class CascadeTests: XCTestCase {
         }
 
         XCTAssertEqual(res.events, [
-            error(210, testError)
+            .error(210, testError)
             ])
 
         XCTAssertEqual(xs.subscriptions, [
@@ -218,34 +218,34 @@ class CascadeTests: XCTestCase {
 
     func testCascadeErrorOnSecond() {
         let xs = scheduler.createHotObservable([
-            next(110, 1),
-            next(180, 2),
-            next(230, 3),
-            next(270, 4),
-            next(340, 5),
-            next(380, 6),
-            next(390, 7),
-            next(450, 8),
-            next(470, 9),
-            next(560, 10),
-            next(580, 11),
-            completed(600),
-            next(610, 12),
-            error(620, testError),
-            completed(630)
+            .next(110, 1),
+            .next(180, 2),
+            .next(230, 3),
+            .next(270, 4),
+            .next(340, 5),
+            .next(380, 6),
+            .next(390, 7),
+            .next(450, 8),
+            .next(470, 9),
+            .next(560, 10),
+            .next(580, 11),
+            .completed(600),
+            .next(610, 12),
+            .error(620, testError),
+            .completed(630)
             ])
 
         let ys = scheduler.createHotObservable([
-            next(350, 26),
-            next(390, 27),
-            next(450, 28),
-            error(480, testError),
-            completed(630)
+            .next(350, 26),
+            .next(390, 27),
+            .next(450, 28),
+            .error(480, testError),
+            .completed(630)
             ])
 
         let zs = scheduler.createHotObservable([
-            next(500, 130),
-            error(520, testError)
+            .next(500, 130),
+            .error(520, testError)
             ])
 
         let res = scheduler.start { () -> Observable<Int> in
@@ -253,13 +253,13 @@ class CascadeTests: XCTestCase {
         }
 
         XCTAssertEqual(res.events, [
-            next(230, 3),
-            next(270, 4),
-            next(340, 5),
-            next(350, 26),
-            next(390, 27),
-            next(450, 28),
-            error(480, testError)
+            .next(230, 3),
+            .next(270, 4),
+            .next(340, 5),
+            .next(350, 26),
+            .next(390, 27),
+            .next(450, 28),
+            .error(480, testError)
             ])
 
         XCTAssertEqual(xs.subscriptions, [
@@ -277,31 +277,31 @@ class CascadeTests: XCTestCase {
 
     func testOutOfOrderCompletion() {
         let xs = scheduler.createHotObservable([
-            next(110, 1),
-            next(180, 2),
-            next(230, 3),
-            next(270, 4),
-            next(340, 5),
-            next(380, 6),
-            next(390, 7),
-            next(450, 8),
-            next(470, 9),
-            next(560, 10),
-            next(580, 11),
-            completed(600),
-            next(610, 12),
-            error(620, testError),
-            completed(630)
+            .next(110, 1),
+            .next(180, 2),
+            .next(230, 3),
+            .next(270, 4),
+            .next(340, 5),
+            .next(380, 6),
+            .next(390, 7),
+            .next(450, 8),
+            .next(470, 9),
+            .next(560, 10),
+            .next(580, 11),
+            .completed(600),
+            .next(610, 12),
+            .error(620, testError),
+            .completed(630)
             ])
 
         let ys = scheduler.createHotObservable([
-            next(350, 26),
-            next(390, 27),
-            completed(500)
+            .next(350, 26),
+            .next(390, 27),
+            .completed(500)
             ])
 
         let zs = scheduler.createHotObservable([
-            completed(400, Int.self)
+            .completed(400, Int.self)
             ])
 
         let res = scheduler.start { () -> Observable<Int> in
@@ -309,12 +309,12 @@ class CascadeTests: XCTestCase {
         }
 
         XCTAssertEqual(res.events, [
-            next(230, 3),
-            next(270, 4),
-            next(340, 5),
-            next(350, 26),
-            next(390, 27),
-            completed(500)
+            .next(230, 3),
+            .next(270, 4),
+            .next(340, 5),
+            .next(350, 26),
+            .next(390, 27),
+            .completed(500)
             ])
 
         XCTAssertEqual(xs.subscriptions, [
@@ -332,21 +332,21 @@ class CascadeTests: XCTestCase {
 
     func testImmediateCompletion() {
         let xs = scheduler.createHotObservable([
-            next(110, 1),
-            next(180, 2),
-            next(230, 3),
-            next(270, 4),
-            next(340, 5),
-            completed(400)
+            .next(110, 1),
+            .next(180, 2),
+            .next(230, 3),
+            .next(270, 4),
+            .next(340, 5),
+            .completed(400)
             ])
 
         let ys = scheduler.createHotObservable([
-            next(100, 21),
-            completed(210, Int.self)
+            .next(100, 21),
+            .completed(210, Int.self)
             ])
 
         let zs = scheduler.createHotObservable([
-            completed(350, Int.self)
+            .completed(350, Int.self)
             ])
 
         let res = scheduler.start { () -> Observable<Int> in
@@ -354,10 +354,10 @@ class CascadeTests: XCTestCase {
         }
 
         XCTAssertEqual(res.events, [
-            next(230, 3),
-            next(270, 4),
-            next(340, 5),
-            completed(400)
+            .next(230, 3),
+            .next(270, 4),
+            .next(340, 5),
+            .completed(400)
             ])
 
         XCTAssertEqual(xs.subscriptions, [

--- a/Tests/RxSwift/catchErrorJustCompleteTests.swift
+++ b/Tests/RxSwift/catchErrorJustCompleteTests.swift
@@ -19,7 +19,7 @@ class CatchErrorJustCompleteTests: XCTestCase {
         let scheduler = TestScheduler(initialClock: 0)
 
         let events: [Recorded<Event<Int>>] = [
-            completed(250)]
+            .completed(250)]
         let xs = scheduler.createColdObservable(events)
 
         let res = scheduler.start {
@@ -27,7 +27,7 @@ class CatchErrorJustCompleteTests: XCTestCase {
         }
 
         XCTAssertEqual(res.events, [
-            completed(450)
+            .completed(450)
             ])
 
         XCTAssertEqual(xs.subscriptions, [
@@ -39,10 +39,10 @@ class CatchErrorJustCompleteTests: XCTestCase {
         let scheduler = TestScheduler(initialClock: 0)
 
         let xs = scheduler.createColdObservable([
-            next(100, 1),
-            next(150, 2),
-            next(200, 3),
-            completed(250)
+            .next(100, 1),
+            .next(150, 2),
+            .next(200, 3),
+            .completed(250)
             ])
 
         let res = scheduler.start {
@@ -50,10 +50,10 @@ class CatchErrorJustCompleteTests: XCTestCase {
         }
 
         XCTAssertEqual(res.events, [
-            next(300, 1),
-            next(350, 2),
-            next(400, 3),
-            completed(450)
+            .next(300, 1),
+            .next(350, 2),
+            .next(400, 3),
+            .completed(450)
             ])
 
         XCTAssertEqual(xs.subscriptions, [
@@ -65,9 +65,9 @@ class CatchErrorJustCompleteTests: XCTestCase {
         let scheduler = TestScheduler(initialClock: 0)
 
         let xs = scheduler.createColdObservable([
-            next(100, 1),
-            next(150, 2),
-            next(200, 3)
+            .next(100, 1),
+            .next(150, 2),
+            .next(200, 3)
             ])
 
         let res = scheduler.start {
@@ -75,9 +75,9 @@ class CatchErrorJustCompleteTests: XCTestCase {
         }
 
         XCTAssertEqual(res.events, [
-            next(300, 1),
-            next(350, 2),
-            next(400, 3)
+            .next(300, 1),
+            .next(350, 2),
+            .next(400, 3)
             ])
 
         XCTAssertEqual(xs.subscriptions, [
@@ -89,9 +89,9 @@ class CatchErrorJustCompleteTests: XCTestCase {
         let scheduler = TestScheduler(initialClock: 0)
 
         let xs = scheduler.createColdObservable([
-            next(100, 1),
-            next(150, 2),
-            error(250, testError)
+            .next(100, 1),
+            .next(150, 2),
+            .error(250, testError)
             ])
 
         let res = scheduler.start {
@@ -99,9 +99,9 @@ class CatchErrorJustCompleteTests: XCTestCase {
         }
 
         XCTAssertEqual(res.events, [
-            next(300, 1),
-            next(350, 2),
-            completed(450)
+            .next(300, 1),
+            .next(350, 2),
+            .completed(450)
             ])
 
         XCTAssertEqual(xs.subscriptions, [

--- a/Tests/RxSwift/filterMapTests.swift
+++ b/Tests/RxSwift/filterMapTests.swift
@@ -31,8 +31,9 @@ class FilterMapTests: XCTestCase {
 
         var correct = values
             .filter { $0 % 2 != 0 }
-            .map { next(0, 2*$0) }
-        correct.append(completed(0))
+            .map { Recorded.next(0, 2 * $0) }
+
+        correct.append(.completed(0))
 
         XCTAssertEqual(observer.events, correct)
     }
@@ -53,11 +54,11 @@ class FilterMapTests: XCTestCase {
 
         scheduler.start()
 
-        let correct = [
-            next(0, 2),
-            next(0, 6),
-            error(0, FilterMapTestError.error)
-        ]
+        let correct = Recorded.events([
+            .next(0, 2),
+            .next(0, 6),
+            .error(0, FilterMapTestError.error)
+        ])
 
         print(observer.events)
 

--- a/Tests/RxSwift/fromAsyncTests.swift
+++ b/Tests/RxSwift/fromAsyncTests.swift
@@ -15,13 +15,13 @@ import RxTest
 class FromAsyncTests: XCTestCase {
     private var scheduler: TestScheduler!
     private var observer: TestableObserver<String>!
-    
+
     override func setUp() {
         super.setUp()
         scheduler = TestScheduler(initialClock: 0)
         observer = scheduler.createObserver(String.self)
     }
-    
+
     override func tearDown() {
         scheduler = nil
         observer = nil
@@ -32,8 +32,8 @@ class FromAsyncTests: XCTestCase {
         var correct = [Recorded<Event<String>>]()
 
         service(arg1: "Foo", arg2: 0) { result in
-            correct.append(next(0, result))
-            correct.append(completed(0))
+            correct.append(.next(0, result))
+            correct.append(.completed(0))
         }
 
         _ = Observable
@@ -44,7 +44,7 @@ class FromAsyncTests: XCTestCase {
 
         XCTAssertEqual(observer.events, correct)
     }
-    
+
     func testSingleResultEqualitySuccessCase() {
         // given
         let result = "result"
@@ -58,7 +58,7 @@ class FromAsyncTests: XCTestCase {
         // then
         XCTAssertEqual(observer.events, expectedEvents)
     }
-    
+
     func testSingleOptionalResultEqualitySuccessCase() {
         // given
         let result: String? = nil
@@ -73,7 +73,7 @@ class FromAsyncTests: XCTestCase {
         // then
         XCTAssertEqual(observer.events, expectedEvents)
     }
-    
+
     func testSingleResultEqualityErrorCase() {
         // given
         let expectedEvents: [Recorded<Event<String>>] = [.error(0, TestError())]
@@ -86,27 +86,27 @@ class FromAsyncTests: XCTestCase {
         // then
         XCTAssertEqual(observer.events, expectedEvents)
     }
-    
+
     // MARK: - Private utils
     private struct TestError: Error {
     }
-    
+
     private func service(arg1: String, arg2: Int, completionHandler: (String) -> Void) {
         completionHandler("Result")
     }
-    
+
     private func serviceWithError(result: String, completionHandler: (String?, TestError?) -> Void) {
         completionHandler(result, nil)
     }
-    
+
     private func serviceWithOptionalResult(result: String?, completionHandler: (String??, TestError?) -> Void) {
         completionHandler(result, nil)
     }
-    
+
     private func serviceThrowingError(completionHandler: (String?, TestError?) -> Void) {
         completionHandler(nil, TestError())
     }
-    
+
     private func serviceWithOptionalResult(completionHandler: (String??, TestError?) -> Void) {
         completionHandler(.some(nil), nil)
     }

--- a/Tests/RxSwift/ignoreErrorsTests.swift
+++ b/Tests/RxSwift/ignoreErrorsTests.swift
@@ -23,10 +23,10 @@ class IgnoreErrorsTests: XCTestCase {
         let scheduler = TestScheduler(initialClock: 0)
 
         let xs = scheduler.createColdObservable([
-            next(100, 1),
-            next(150, 2),
-            next(200, 3),
-            completed(250)
+            .next(100, 1),
+            .next(150, 2),
+            .next(200, 3),
+            .completed(250)
             ])
 
         let res = scheduler.start {
@@ -34,10 +34,10 @@ class IgnoreErrorsTests: XCTestCase {
         }
 
         XCTAssertEqual(res.events, [
-            next(300, 1),
-            next(350, 2),
-            next(400, 3),
-            completed(450)
+            .next(300, 1),
+            .next(350, 2),
+            .next(400, 3),
+            .completed(450)
             ])
 
         XCTAssertEqual(xs.subscriptions, [
@@ -49,9 +49,9 @@ class IgnoreErrorsTests: XCTestCase {
         let scheduler = TestScheduler(initialClock: 0)
 
         let xs = scheduler.createColdObservable([
-            next(100, 1),
-            next(150, 2),
-            next(200, 3)
+            .next(100, 1),
+            .next(150, 2),
+            .next(200, 3)
             ])
 
         let res = scheduler.start {
@@ -59,9 +59,9 @@ class IgnoreErrorsTests: XCTestCase {
         }
 
         XCTAssertEqual(res.events, [
-            next(300, 1),
-            next(350, 2),
-            next(400, 3)
+            .next(300, 1),
+            .next(350, 2),
+            .next(400, 3)
             ])
 
         XCTAssertEqual(xs.subscriptions, [
@@ -73,10 +73,10 @@ class IgnoreErrorsTests: XCTestCase {
         let scheduler = TestScheduler(initialClock: 0)
 
         let xs = scheduler.createColdObservable([
-            next(100, 1),
-            next(150, 2),
-            next(200, 3),
-            error(250, testError)
+            .next(100, 1),
+            .next(150, 2),
+            .next(200, 3),
+            .error(250, testError)
             ])
 
         let res = scheduler.start(disposed: 1100) {
@@ -84,16 +84,16 @@ class IgnoreErrorsTests: XCTestCase {
         }
 
         XCTAssertEqual(res.events, [
-            next(300, 1),
-            next(350, 2),
-            next(400, 3),
-            next(550, 1),
-            next(600, 2),
-            next(650, 3),
-            next(800, 1),
-            next(850, 2),
-            next(900, 3),
-            next(1050, 1)
+            .next(300, 1),
+            .next(350, 2),
+            .next(400, 3),
+            .next(550, 1),
+            .next(600, 2),
+            .next(650, 3),
+            .next(800, 1),
+            .next(850, 2),
+            .next(900, 3),
+            .next(1050, 1)
             ])
 
         XCTAssertEqual(xs.subscriptions, [
@@ -109,10 +109,10 @@ class IgnoreErrorsTests: XCTestCase {
         var counter = 0
 
         let xs = scheduler.createColdObservable([
-            next(5, 1),
-            next(10, 2),
-            next(15, 3),
-            error(20, testError)
+            .next(5, 1),
+            .next(10, 2),
+            .next(15, 3),
+            .error(20, testError)
             ])
 
         let res = scheduler.start {
@@ -123,16 +123,16 @@ class IgnoreErrorsTests: XCTestCase {
         }
 
         XCTAssertEqual(res.events, [
-            next(205, 1),
-            next(210, 2),
-            next(215, 3),
-            next(225, 1),
-            next(230, 2),
-            next(235, 3),
-            next(245, 1),
-            next(250, 2),
-            next(255, 3),
-            error(260, testError)
+            .next(205, 1),
+            .next(210, 2),
+            .next(215, 3),
+            .next(225, 1),
+            .next(230, 2),
+            .next(235, 3),
+            .next(245, 1),
+            .next(250, 2),
+            .next(255, 3),
+            .error(260, testError)
             ])
 
         XCTAssertEqual(xs.subscriptions, [
@@ -146,10 +146,10 @@ class IgnoreErrorsTests: XCTestCase {
         let scheduler = TestScheduler(initialClock: 0)
 
         let xs = scheduler.createColdObservable([
-            next(5, 1),
-            next(10, 2),
-            next(15, 3),
-            error(20, testError)
+            .next(5, 1),
+            .next(10, 2),
+            .next(15, 3),
+            .error(20, testError)
             ])
 
         let res = scheduler.start(disposed: 231) {
@@ -159,11 +159,11 @@ class IgnoreErrorsTests: XCTestCase {
         }
 
         XCTAssertEqual(res.events, [
-            next(205, 1),
-            next(210, 2),
-            next(215, 3),
-            next(225, 1),
-            next(230, 2)
+            .next(205, 1),
+            .next(210, 2),
+            .next(215, 3),
+            .next(225, 1),
+            .next(230, 2)
             ])
 
         XCTAssertEqual(xs.subscriptions, [
@@ -176,10 +176,10 @@ class IgnoreErrorsTests: XCTestCase {
         let scheduler = TestScheduler(initialClock: 0)
 
         let xs = scheduler.createColdObservable([
-            next(100, 1),
-            next(150, 2),
-            next(200, 3),
-            completed(250)
+            .next(100, 1),
+            .next(150, 2),
+            .next(200, 3),
+            .completed(250)
             ])
 
         let res = scheduler.start {
@@ -189,10 +189,10 @@ class IgnoreErrorsTests: XCTestCase {
         }
 
         XCTAssertEqual(res.events, [
-            next(300, 1),
-            next(350, 2),
-            next(400, 3),
-            completed(450)
+            .next(300, 1),
+            .next(350, 2),
+            .next(400, 3),
+            .completed(450)
             ])
 
         XCTAssertEqual(xs.subscriptions, [

--- a/Tests/RxSwift/ignoreWhenTests.swift
+++ b/Tests/RxSwift/ignoreWhenTests.swift
@@ -38,21 +38,21 @@ class IgnoreWhenTests: XCTestCase {
         var invoked = 0
 
         let xs = scheduler.createHotObservable([
-            next(110, 1),
-            next(180, 2),
-            next(230, 3),
-            next(270, 4),
-            next(340, 5),
-            next(380, 6),
-            next(390, 7),
-            next(450, 8),
-            next(470, 9),
-            next(560, 10),
-            next(580, 11),
-            completed(600),
-            next(610, 12),
-            error(620, testError),
-            completed(630)
+            .next(110, 1),
+            .next(180, 2),
+            .next(230, 3),
+            .next(270, 4),
+            .next(340, 5),
+            .next(380, 6),
+            .next(390, 7),
+            .next(450, 8),
+            .next(470, 9),
+            .next(560, 10),
+            .next(580, 11),
+            .completed(600),
+            .next(610, 12),
+            .error(620, testError),
+            .completed(630)
             ])
 
         let res = scheduler.start { () -> Observable<Int> in
@@ -63,11 +63,11 @@ class IgnoreWhenTests: XCTestCase {
         }
 
         XCTAssertEqual(res.events, [
-            next(230, 3),
-            next(340, 5),
-            next(390, 7),
-            next(580, 11),
-            completed(600)
+            .next(230, 3),
+            .next(340, 5),
+            .next(390, 7),
+            .next(580, 11),
+            .completed(600)
             ])
 
         XCTAssertEqual(xs.subscriptions, [
@@ -83,18 +83,18 @@ class IgnoreWhenTests: XCTestCase {
         var invoked = 0
 
         let xs = scheduler.createHotObservable([
-            next(110, 1),
-            next(180, 2),
-            next(230, 3),
-            next(270, 4),
-            next(340, 5),
-            next(380, 6),
-            next(390, 7),
-            next(450, 8),
-            next(470, 9),
-            next(560, 10),
-            next(580, 11),
-            completed(600)
+            .next(110, 1),
+            .next(180, 2),
+            .next(230, 3),
+            .next(270, 4),
+            .next(340, 5),
+            .next(380, 6),
+            .next(390, 7),
+            .next(450, 8),
+            .next(470, 9),
+            .next(560, 10),
+            .next(580, 11),
+            .completed(600)
             ])
 
         let res = scheduler.start { () -> Observable<Int> in
@@ -105,16 +105,16 @@ class IgnoreWhenTests: XCTestCase {
         }
 
         XCTAssertEqual(res.events, [
-            next(230, 3),
-            next(270, 4),
-            next(340, 5),
-            next(380, 6),
-            next(390, 7),
-            next(450, 8),
-            next(470, 9),
-            next(560, 10),
-            next(580, 11),
-            completed(600)
+            .next(230, 3),
+            .next(270, 4),
+            .next(340, 5),
+            .next(380, 6),
+            .next(390, 7),
+            .next(450, 8),
+            .next(470, 9),
+            .next(560, 10),
+            .next(580, 11),
+            .completed(600)
             ])
 
         XCTAssertEqual(xs.subscriptions, [
@@ -130,18 +130,18 @@ class IgnoreWhenTests: XCTestCase {
         var invoked = 0
 
         let xs = scheduler.createHotObservable([
-            next(110, 1),
-            next(180, 2),
-            next(230, 3),
-            next(270, 4),
-            next(340, 5),
-            next(380, 6),
-            next(390, 7),
-            next(450, 8),
-            next(470, 9),
-            next(560, 10),
-            next(580, 11),
-            completed(600)
+            .next(110, 1),
+            .next(180, 2),
+            .next(230, 3),
+            .next(270, 4),
+            .next(340, 5),
+            .next(380, 6),
+            .next(390, 7),
+            .next(450, 8),
+            .next(470, 9),
+            .next(560, 10),
+            .next(580, 11),
+            .completed(600)
             ])
 
         let res = scheduler.start { () -> Observable<Int> in
@@ -152,7 +152,7 @@ class IgnoreWhenTests: XCTestCase {
         }
 
         XCTAssertEqual(res.events, [
-            completed(600)
+            .completed(600)
             ])
 
         XCTAssertEqual(xs.subscriptions, [
@@ -167,18 +167,18 @@ class IgnoreWhenTests: XCTestCase {
         var invoked = 0
 
         let xs = scheduler.createHotObservable([
-            next(110, 1),
-            next(180, 2),
-            next(230, 3),
-            next(270, 4),
-            next(340, 5),
-            next(380, 6),
-            next(390, 7),
-            next(450, 8),
-            next(470, 9),
-            next(560, 10),
-            next(580, 11),
-            completed(600)
+            .next(110, 1),
+            .next(180, 2),
+            .next(230, 3),
+            .next(270, 4),
+            .next(340, 5),
+            .next(380, 6),
+            .next(390, 7),
+            .next(450, 8),
+            .next(470, 9),
+            .next(560, 10),
+            .next(580, 11),
+            .completed(600)
             ])
 
         let res = scheduler.start(disposed: 400) { () -> Observable<Int> in
@@ -189,9 +189,9 @@ class IgnoreWhenTests: XCTestCase {
         }
 
         XCTAssertEqual(res.events, [
-            next(230, 3),
-            next(340, 5),
-            next(390, 7)
+            .next(230, 3),
+            .next(340, 5),
+            .next(390, 7)
             ])
 
         XCTAssertEqual(xs.subscriptions, [

--- a/Tests/RxSwift/mapToTests.swift
+++ b/Tests/RxSwift/mapToTests.swift
@@ -39,12 +39,12 @@ class MapToTests: XCTestCase {
 
     func testReplaceWithResultValues() {
         // test elements values and type
-        let correctValues = [
-            next(0, "candy"),
-            next(0, "candy"),
-            next(0, "candy"),
-            completed(0)
-        ]
+        let correctValues = Recorded.events([
+            .next(0, "candy"),
+            .next(0, "candy"),
+            .next(0, "candy"),
+            .completed(0)
+        ])
         XCTAssertEqual(observer.events, correctValues)
     }
 }

--- a/Tests/RxSwift/materialized+elementsTests.swift
+++ b/Tests/RxSwift/materialized+elementsTests.swift
@@ -21,12 +21,12 @@ final class MaterializedElementsTests: XCTestCase {
 		super.setUp()
 		testScheduler = TestScheduler(initialClock: 0)
 		eventObservable = testScheduler.createHotObservable([
-				next(0, Event.next(0)),
-				next(100, Event.next(1)),
-				next(200, Event.error(dummyError)),
-				next(300, Event.next(2)),
-				next(400, Event.error(dummyError)),
-				next(500, Event.next(3))
+            .next(0, Event.next(0)),
+            .next(100, Event.next(1)),
+            .next(200, Event.error(dummyError)),
+            .next(300, Event.next(2)),
+            .next(400, Event.error(dummyError)),
+            .next(500, Event.next(3))
 		]).asObservable()
 	}
 
@@ -45,10 +45,10 @@ final class MaterializedElementsTests: XCTestCase {
 		testScheduler.start()
 
 		XCTAssertEqual(observer.events, [
-				next(0, 0),
-				next(100, 1),
-				next(300, 2),
-				next(500, 3)
+            .next(0, 0),
+            .next(100, 1),
+            .next(300, 2),
+            .next(500, 3)
 		])
 	}
 

--- a/Tests/RxSwift/notTests.swift
+++ b/Tests/RxSwift/notTests.swift
@@ -26,12 +26,12 @@ class NotTests: XCTestCase {
 
         scheduler.start()
 
-        let correct = [
-            next(0, false),
-            next(0, true),
-            next(0, false),
-            completed(0)
-        ]
+        let correct = Recorded.events([
+            .next(0, false),
+            .next(0, true),
+            .next(0, false),
+            .completed(0)
+        ])
 
         XCTAssertEqual(observer.events, correct)
     }

--- a/Tests/RxSwift/nwiseTests.swift
+++ b/Tests/RxSwift/nwiseTests.swift
@@ -26,15 +26,15 @@ class NwiseTests: XCTestCase {
         scheduler.start()
 
         let correct: [Recorded<Event<EquatableArray<Int>>>] = [
-            next(0, EquatableArray([1, 2, 3])),
-            next(0, EquatableArray([2, 3, 4])),
-            next(0, EquatableArray([3, 4, 5])),
-            next(0, EquatableArray([4, 5, 6])),
-            next(0, EquatableArray([5, 6, 7])),
-            next(0, EquatableArray([6, 7, 8])),
-            next(0, EquatableArray([7, 8, 9])),
-            next(0, EquatableArray([8, 9, 10])),
-            completed(0)
+            .next(0, EquatableArray([1, 2, 3])),
+            .next(0, EquatableArray([2, 3, 4])),
+            .next(0, EquatableArray([3, 4, 5])),
+            .next(0, EquatableArray([4, 5, 6])),
+            .next(0, EquatableArray([5, 6, 7])),
+            .next(0, EquatableArray([6, 7, 8])),
+            .next(0, EquatableArray([7, 8, 9])),
+            .next(0, EquatableArray([8, 9, 10])),
+            .completed(0)
         ]
 
         XCTAssertEqual(observer.events, correct)
@@ -53,7 +53,7 @@ class NwiseTests: XCTestCase {
         scheduler.start()
 
         let correct: [Recorded<Event<EquatableArray<Int>>>] = [
-            completed(0)
+            .completed(0)
         ]
 
         XCTAssertEqual(observer.events, correct)
@@ -76,9 +76,9 @@ class NwiseTests: XCTestCase {
         scheduler.start()
 
         let correct: [Recorded<Event<EquatableArray<Int>>>] = [
-            next(0, EquatableArray([1, 2, 3])),
-            next(0, EquatableArray([2, 3, 4])),
-            error(0, DummyError.expected)
+            .next(0, EquatableArray([1, 2, 3])),
+            .next(0, EquatableArray([2, 3, 4])),
+            .error(0, DummyError.expected)
         ]
 
         XCTAssertEqual(observer.events, correct)
@@ -99,18 +99,18 @@ class NwiseTests: XCTestCase {
 
         scheduler.start()
 
-        let correct = [
-            next(0, "1 2"),
-            next(0, "2 3"),
-            next(0, "3 4"),
-            next(0, "4 5"),
-            next(0, "5 6"),
-            next(0, "6 7"),
-            next(0, "7 8"),
-            next(0, "8 9"),
-            next(0, "9 10"),
-            completed(0)
-        ]
+        let correct = Recorded.events([
+            .next(0, "1 2"),
+            .next(0, "2 3"),
+            .next(0, "3 4"),
+            .next(0, "4 5"),
+            .next(0, "5 6"),
+            .next(0, "6 7"),
+            .next(0, "7 8"),
+            .next(0, "8 9"),
+            .next(0, "9 10"),
+            .completed(0)
+        ])
 
         XCTAssertEqual(observer.events, correct)
     }
@@ -129,7 +129,7 @@ class NwiseTests: XCTestCase {
         scheduler.start()
 
         let correct: [Recorded<Event<String>>] = [
-            completed(0)
+            .completed(0)
         ]
 
         XCTAssertEqual(observer.events, correct)
@@ -151,12 +151,12 @@ class NwiseTests: XCTestCase {
         subject.onError(DummyError.expected)
         scheduler.start()
 
-        let correct = [
-            next(0, "1 2"),
-            next(0, "2 3"),
-            next(0, "3 4"),
-            error(0, DummyError.expected)
-        ]
+        let correct = Recorded.events([
+            .next(0, "1 2"),
+            .next(0, "2 3"),
+            .next(0, "3 4"),
+            .error(0, DummyError.expected)
+        ])
 
         XCTAssertEqual(observer.events, correct)
     }
@@ -173,6 +173,6 @@ private struct EquatableArray<Element: Equatable> : Equatable {
     }
 }
 
-private func == <E>(lhs: EquatableArray<E>, rhs: EquatableArray<E>) -> Bool {
+private func == <Element>(lhs: EquatableArray<Element>, rhs: EquatableArray<Element>) -> Bool {
     return lhs.elements == rhs.elements
 }

--- a/Tests/RxSwift/pausableBufferedTests.swift
+++ b/Tests/RxSwift/pausableBufferedTests.swift
@@ -18,19 +18,19 @@ class PausableBufferedTests: XCTestCase {
 
     func testPausedNoSkip() {
         let underlying = scheduler.createHotObservable([
-            next(150, 1),
-            next(210, 2),
-            next(230, 3),
-            next(301, 4),
-            next(350, 5),
-            next(399, 6),
-            completed(500)
+            .next(150, 1),
+            .next(210, 2),
+            .next(230, 3),
+            .next(301, 4),
+            .next(350, 5),
+            .next(399, 6),
+            .completed(500)
             ])
 
         let pauser = scheduler.createHotObservable([
-            next(201, true),
-            next(205, false),
-            next(209, true)
+            .next(201, true),
+            .next(205, false),
+            .next(209, true)
             ])
 
         let res = scheduler.start(disposed: 1000) {
@@ -38,12 +38,12 @@ class PausableBufferedTests: XCTestCase {
         }
 
         XCTAssertEqual(res.events, [
-            next(210, 2),
-            next(230, 3),
-            next(301, 4),
-            next(350, 5),
-            next(399, 6),
-            completed(500)
+            .next(210, 2),
+            .next(230, 3),
+            .next(301, 4),
+            .next(350, 5),
+            .next(399, 6),
+            .completed(500)
             ])
 
         XCTAssertEqual(underlying.subscriptions, [
@@ -53,19 +53,19 @@ class PausableBufferedTests: XCTestCase {
 
     func testPausedSkips() {
         let underlying = scheduler.createHotObservable([
-            next(150, 1),
-            next(210, 2),
-            next(230, 3),
-            next(301, 4),
-            next(350, 5),
-            next(399, 6),
-            completed(500)
+            .next(150, 1),
+            .next(210, 2),
+            .next(230, 3),
+            .next(301, 4),
+            .next(350, 5),
+            .next(399, 6),
+            .completed(500)
             ])
 
         let pauser = scheduler.createHotObservable([
-            next(220, true),
-            next(300, false),
-            next(400, true)
+            .next(220, true),
+            .next(300, false),
+            .next(400, true)
             ])
 
         let res = scheduler.start(disposed: 1000) {
@@ -73,10 +73,10 @@ class PausableBufferedTests: XCTestCase {
         }
 
         XCTAssertEqual(res.events, [
-            next(220, 2),
-            next(230, 3),
-            next(400, 6),
-            completed(500)
+            .next(220, 2),
+            .next(230, 3),
+            .next(400, 6),
+            .completed(500)
             ])
 
         XCTAssertEqual(underlying.subscriptions, [
@@ -86,19 +86,19 @@ class PausableBufferedTests: XCTestCase {
 
     func testPausedLimit() {
         let underlying = scheduler.createHotObservable([
-            next(150, 1),
-            next(210, 2),
-            next(230, 3),
-            next(301, 4),
-            next(350, 5),
-            next(399, 6),
-            completed(500)
+            .next(150, 1),
+            .next(210, 2),
+            .next(230, 3),
+            .next(301, 4),
+            .next(350, 5),
+            .next(399, 6),
+            .completed(500)
             ])
 
         let pauser = scheduler.createHotObservable([
-            next(220, true),
-            next(300, false),
-            next(400, true)
+            .next(220, true),
+            .next(300, false),
+            .next(400, true)
             ])
 
         let res = scheduler.start(disposed: 1000) {
@@ -106,11 +106,11 @@ class PausableBufferedTests: XCTestCase {
         }
 
         XCTAssertEqual(res.events, [
-            next(220, 2),
-            next(230, 3),
-            next(400, 5),
-            next(400, 6),
-            completed(500)
+            .next(220, 2),
+            .next(230, 3),
+            .next(400, 5),
+            .next(400, 6),
+            .completed(500)
             ])
 
         XCTAssertEqual(underlying.subscriptions, [
@@ -120,19 +120,19 @@ class PausableBufferedTests: XCTestCase {
 
     func testPausedNoLimit() {
         let underlying = scheduler.createHotObservable([
-            next(150, 1),
-            next(210, 2),
-            next(230, 3),
-            next(301, 4),
-            next(350, 5),
-            next(399, 6),
-            completed(500)
+            .next(150, 1),
+            .next(210, 2),
+            .next(230, 3),
+            .next(301, 4),
+            .next(350, 5),
+            .next(399, 6),
+            .completed(500)
             ])
 
         let pauser = scheduler.createHotObservable([
-            next(220, true),
-            next(300, false),
-            next(400, true)
+            .next(220, true),
+            .next(300, false),
+            .next(400, true)
             ])
 
         let res = scheduler.start(disposed: 1000) {
@@ -140,12 +140,12 @@ class PausableBufferedTests: XCTestCase {
         }
 
         XCTAssertEqual(res.events, [
-            next(220, 2),
-            next(230, 3),
-            next(400, 4),
-            next(400, 5),
-            next(400, 6),
-            completed(500)
+            .next(220, 2),
+            .next(230, 3),
+            .next(400, 4),
+            .next(400, 5),
+            .next(400, 6),
+            .completed(500)
             ])
 
         XCTAssertEqual(underlying.subscriptions, [
@@ -155,20 +155,20 @@ class PausableBufferedTests: XCTestCase {
 
     func testPausedError() {
         let underlying = scheduler.createHotObservable([
-            next(150, 1),
-            next(210, 2),
-            error(230, testError),
-            next(301, 4),
-            next(350, 5),
-            next(399, 6),
-            completed(500)
+            .next(150, 1),
+            .next(210, 2),
+            .error(230, testError),
+            .next(301, 4),
+            .next(350, 5),
+            .next(399, 6),
+            .completed(500)
             ])
 
         let pauser = scheduler.createHotObservable([
-            next(201, true),
-            next(300, false),
-            next(400, true),
-            completed(600)
+            .next(201, true),
+            .next(300, false),
+            .next(400, true),
+            .completed(600)
             ])
 
         let res = scheduler.start(disposed: 1000) {
@@ -176,8 +176,8 @@ class PausableBufferedTests: XCTestCase {
         }
 
         XCTAssertEqual(res.events, [
-            next(210, 2),
-            error(230, testError)
+            .next(210, 2),
+            .error(230, testError)
             ])
 
         XCTAssertEqual(underlying.subscriptions, [

--- a/Tests/RxSwift/pausableTests.swift
+++ b/Tests/RxSwift/pausableTests.swift
@@ -18,19 +18,19 @@ class PausableTests: XCTestCase {
 
     func testPausedNoSkip() {
         let underlying = scheduler.createHotObservable([
-            next(150, 1),
-            next(210, 2),
-            next(230, 3),
-            next(301, 4),
-            next(350, 5),
-            next(399, 6),
-            completed(500)
+            .next(150, 1),
+            .next(210, 2),
+            .next(230, 3),
+            .next(301, 4),
+            .next(350, 5),
+            .next(399, 6),
+            .completed(500)
         ])
 
         let pauser = scheduler.createHotObservable([
-            next(201, true),
-            next(205, false),
-            next(209, true)
+            .next(201, true),
+            .next(205, false),
+            .next(209, true)
         ])
 
         let res = scheduler.start(disposed: 1000) {
@@ -38,12 +38,12 @@ class PausableTests: XCTestCase {
         }
 
         XCTAssertEqual(res.events, [
-            next(210, 2),
-            next(230, 3),
-            next(301, 4),
-            next(350, 5),
-            next(399, 6),
-            completed(500)
+            .next(210, 2),
+            .next(230, 3),
+            .next(301, 4),
+            .next(350, 5),
+            .next(399, 6),
+            .completed(500)
         ])
 
         XCTAssertEqual(underlying.subscriptions, [
@@ -54,19 +54,19 @@ class PausableTests: XCTestCase {
 
     func testPausedSkips() {
         let underlying = scheduler.createHotObservable([
-            next(150, 1),
-            next(210, 2),
-            next(230, 3),
-            next(301, 4),
-            next(350, 5),
-            next(399, 6),
-            completed(500)
+            .next(150, 1),
+            .next(210, 2),
+            .next(230, 3),
+            .next(301, 4),
+            .next(350, 5),
+            .next(399, 6),
+            .completed(500)
         ])
 
         let pauser = scheduler.createHotObservable([
-            next(220, true),
-            next(300, false),
-            next(400, true)
+            .next(220, true),
+            .next(300, false),
+            .next(400, true)
         ])
 
         let res = scheduler.start(disposed: 1000) {
@@ -74,8 +74,8 @@ class PausableTests: XCTestCase {
         }
 
         XCTAssertEqual(res.events, [
-            next(230, 3),
-            completed(500)
+            .next(230, 3),
+            .completed(500)
         ])
 
         XCTAssertEqual(underlying.subscriptions, [
@@ -86,19 +86,19 @@ class PausableTests: XCTestCase {
 
     func testPausedError() {
         let underlying = scheduler.createHotObservable([
-            next(150, 1),
-            next(210, 2),
-            error(230, testError),
-            next(301, 4),
-            next(350, 5),
-            next(399, 6),
-            completed(500)
+            .next(150, 1),
+            .next(210, 2),
+            .error(230, testError),
+            .next(301, 4),
+            .next(350, 5),
+            .next(399, 6),
+            .completed(500)
         ])
 
         let pauser = scheduler.createHotObservable([
-            next(201, true),
-            next(300, false),
-            next(400, true)
+            .next(201, true),
+            .next(300, false),
+            .next(400, true)
         ])
 
         let res = scheduler.start(disposed: 1000) {
@@ -106,8 +106,8 @@ class PausableTests: XCTestCase {
         }
 
         XCTAssertEqual(res.events, [
-            next(210, 2),
-            error(230, testError)
+            .next(210, 2),
+            .error(230, testError)
         ])
 
         XCTAssertEqual(underlying.subscriptions, [

--- a/Tests/RxSwift/repeatWithBehaviorTests.swift
+++ b/Tests/RxSwift/repeatWithBehaviorTests.swift
@@ -26,46 +26,46 @@ class RepeatWithBehaviorTests: XCTestCase {
 		super.setUp()
 
 		sampleValues = scheduler.createColdObservable([
-			next(210, 1),
-			next(220, 2),
-			completed(300)
+			.next(210, 1),
+			.next(220, 2),
+			.completed(300)
 			])
 
         sampleValuesWithError = scheduler.createColdObservable([
-            next(210, 1),
-            error(220, RepeatTestErrors.fatalError)
+            .next(210, 1),
+            .error(220, RepeatTestErrors.fatalError)
             ])
 	}
 
     // MARK: - Valid events
-    let immediateCorrectValues = [
-        next(210, 1),
-        next(220, 2),
-        next(510, 1),
-        next(520, 2),
-        completed(600)]
+    let immediateCorrectValues = Recorded.events([
+        .next(210, 1),
+        .next(220, 2),
+        .next(510, 1),
+        .next(520, 2),
+        .completed(600)])
 
-    let customDelayCorrectValues = [
-        next(210, 1),
-        next(220, 2),
-        next(520, 1),
-        next(530, 2),
-        next(850, 1),
-        next(860, 2),
-        completed(940)]
+    let customDelayCorrectValues = Recorded.events([
+        .next(210, 1),
+        .next(220, 2),
+        .next(520, 1),
+        .next(530, 2),
+        .next(850, 1),
+        .next(860, 2),
+        .completed(940)])
 
-    let exponentialCorrectValues = [
-        next(210, 1),
-        next(220, 2),
-        next(512, 1),
-        next(522, 2),
-        next(818, 1),
-        next(828, 2),
-        completed(908)]
+    let exponentialCorrectValues = Recorded.events([
+        .next(210, 1),
+        .next(220, 2),
+        .next(512, 1),
+        .next(522, 2),
+        .next(818, 1),
+        .next(828, 2),
+        .completed(908)])
 
     let erroredCorrectValues: [Recorded<Event<Int>>] = [
-        next(210, 1),
-        error(220, RepeatTestErrors.fatalError)
+        .next(210, 1),
+        .error(220, RepeatTestErrors.fatalError)
     ]
 
     // MARK: - Immediate repeats
@@ -102,10 +102,10 @@ class RepeatWithBehaviorTests: XCTestCase {
 	}
 
 	func testImmediateNotRepeatWithPredicate() {
-		let correctValues = [
-			next(210, 1),
-			next(220, 2),
-            completed(300)]
+		let correctValues = Recorded.events([
+			.next(210, 1),
+			.next(220, 2),
+            .completed(300)])
 
 		// provide simple predicate that always return false (so, sequence will not repeated)
 		let res = scheduler.start(created: 0, subscribed: 0, disposed: 1000) {
@@ -129,14 +129,14 @@ class RepeatWithBehaviorTests: XCTestCase {
     // MARK: - Delayed repeats
 
 	func testDelayedRepeatWithoutPredicate() {
-		let correctValues = [
-			next(210, 1),
-			next(220, 2),
-			next(511, 1),
-			next(521, 2),
-			next(812, 1),
-			next(822, 2),
-			completed(902)]
+		let correctValues = Recorded.events([
+			.next(210, 1),
+			.next(220, 2),
+			.next(511, 1),
+			.next(521, 2),
+			.next(812, 1),
+			.next(822, 2),
+			.completed(902)])
 
 		let res = scheduler.start(created: 0, subscribed: 0, disposed: 1000) {
 			self.sampleValues.asObservable().repeatWithBehavior(.delayed(maxCount: 3, time: 1.0), scheduler: self.scheduler)
@@ -146,14 +146,14 @@ class RepeatWithBehaviorTests: XCTestCase {
 	}
 
 	func testDelayedRepeatWithPredicate() {
-        let correctValues = [
-            next(210, 1),
-            next(220, 2),
-            next(511, 1),
-            next(521, 2),
-            next(812, 1),
-            next(822, 2),
-            completed(902)]
+        let correctValues = Recorded.events([
+            .next(210, 1),
+            .next(220, 2),
+            .next(511, 1),
+            .next(521, 2),
+            .next(812, 1),
+            .next(822, 2),
+            .completed(902)])
 
         let res = scheduler.start(created: 0, subscribed: 0, disposed: 1000) {
             self.sampleValues
@@ -165,10 +165,11 @@ class RepeatWithBehaviorTests: XCTestCase {
 	}
 
     func testDelayedNotRepeatWithPredicate() {
-		let correctValues = [
-			next(210, 1),
-			next(220, 2),
-			completed(300)]
+		let correctValues = Recorded.events([
+			.next(210, 1),
+			.next(220, 2),
+			.completed(300)])
+
 		let res = scheduler.start(created: 0, subscribed: 0, disposed: 1000) {
 			self.sampleValues
                 .asObservable()
@@ -206,10 +207,10 @@ class RepeatWithBehaviorTests: XCTestCase {
 	}
 
 	func testExponentialNotRepeatWithPredicate() {
-        let correctValues = [
-            next(210, 1),
-            next(220, 2),
-            completed(300)]
+        let correctValues = Recorded.events([
+            .next(210, 1),
+            .next(220, 2),
+            .completed(300)])
 
 		let res = scheduler.start(created: 0, subscribed: 0, disposed: 1000) {
 			self.sampleValues
@@ -232,11 +233,11 @@ class RepeatWithBehaviorTests: XCTestCase {
     // MARK: - Custom delay repeats
 
     // custom delay calculator
-    let customCalculator: (UInt) -> Double = { attempt in
+    let customCalculator: (UInt) -> DispatchTimeInterval = { attempt in
         switch attempt {
-        case 1: return 10.0
-        case 2: return 30.0
-        default: return 0
+        case 1: return .seconds(10)
+        case 2: return .seconds(30)
+        default: return .never
         }
     }
 

--- a/Tests/RxSwift/retryWithBehaviorTests.swift
+++ b/Tests/RxSwift/retryWithBehaviorTests.swift
@@ -25,40 +25,40 @@ class RetryWithBehaviorTests: XCTestCase {
 		super.setUp()
 
 		sampleValues = scheduler.createColdObservable([
-			next(210, 1),
-			next(220, 2),
-			error(230, RepeatTestErrors.fatalError),
-			next(240, 3),
-			next(250, 4),
-			next(260, 5),
-			next(270, 6),
-			completed(300)
+			.next(210, 1),
+			.next(220, 2),
+			.error(230, RepeatTestErrors.fatalError),
+			.next(240, 3),
+			.next(250, 4),
+			.next(260, 5),
+			.next(270, 6),
+			.completed(300)
 			])
 
         sampleValuesImmediateError = scheduler.createColdObservable([
-            error(230, RepeatTestErrors.fatalError)
+            .error(230, RepeatTestErrors.fatalError)
             ])
 
         sampleValuesNeverError = scheduler.createColdObservable([
-            next(210, 1),
-            next(220, 2),
-            next(240, 3),
-            next(250, 4),
-            next(260, 5),
-            next(270, 6),
-            completed(300)
+            .next(210, 1),
+            .next(220, 2),
+            .next(240, 3),
+            .next(250, 4),
+            .next(260, 5),
+            .next(270, 6),
+            .completed(300)
             ])
 	}
 
 	func testImmediateRetryWithoutPredicate() {
-		let correctValues = [
-			next(210, 1),
-			next(220, 2),
-			next(440, 1),
-			next(450, 2),
-			next(670, 1),
-			next(680, 2),
-			error(690, RepeatTestErrors.fatalError)]
+		let correctValues = Recorded.events([
+			.next(210, 1),
+			.next(220, 2),
+			.next(440, 1),
+			.next(450, 2),
+			.next(670, 1),
+			.next(680, 2),
+			.error(690, RepeatTestErrors.fatalError)])
 
         let res = scheduler.start(created: 0, subscribed: 0, disposed: 1000) {
 			self.sampleValues.asObservable().retry(.immediate(maxCount: 3), scheduler: self.scheduler)
@@ -69,7 +69,7 @@ class RetryWithBehaviorTests: XCTestCase {
 
     func testImmediateRetryWithoutPredicate_ImmediateError() {
         let correctValues: [Recorded<Event<Int>>] = [
-            error(690, RepeatTestErrors.fatalError)
+            .error(690, RepeatTestErrors.fatalError)
         ]
 
         let res = scheduler.start(created: 0, subscribed: 0, disposed: 1000) {
@@ -80,15 +80,15 @@ class RetryWithBehaviorTests: XCTestCase {
     }
 
     func testImmediateRetryWithoutPredicate_NoError() {
-        let correctValues = [
-            next(210, 1),
-            next(220, 2),
-            next(240, 3),
-            next(250, 4),
-            next(260, 5),
-            next(270, 6),
-            completed(300)
-        ]
+        let correctValues = Recorded.events([
+            .next(210, 1),
+            .next(220, 2),
+            .next(240, 3),
+            .next(250, 4),
+            .next(260, 5),
+            .next(270, 6),
+            .completed(300)
+        ])
 
         let res = scheduler.start(created: 0, subscribed: 0, disposed: 1000) {
             self.sampleValuesNeverError.asObservable().retry(.immediate(maxCount: 3), scheduler: self.scheduler)
@@ -98,14 +98,14 @@ class RetryWithBehaviorTests: XCTestCase {
     }
 
 	func testImmediateRetryWithPredicate() {
-		let correctValues = [
-			next(210, 1),
-			next(220, 2),
-			next(440, 1),
-			next(450, 2),
-			next(670, 1),
-			next(680, 2),
-			error(690, RepeatTestErrors.fatalError)]
+		let correctValues = Recorded.events([
+			.next(210, 1),
+			.next(220, 2),
+			.next(440, 1),
+			.next(450, 2),
+			.next(670, 1),
+			.next(680, 2),
+			.error(690, RepeatTestErrors.fatalError)])
 
 		// Provide simple predicate that always return true
 		let res = scheduler.start(created: 0, subscribed: 0, disposed: 1000) {
@@ -118,12 +118,12 @@ class RetryWithBehaviorTests: XCTestCase {
 	}
 
     func testImmediateRetryWithPredicate_Limited() {
-        let correctValues = [
-            next(210, 1),
-            next(220, 2),
-            next(440, 1),
-            next(450, 2),
-            error(460, RepeatTestErrors.fatalError)]
+        let correctValues = Recorded.events([
+            .next(210, 1),
+            .next(220, 2),
+            .next(440, 1),
+            .next(450, 2),
+            .error(460, RepeatTestErrors.fatalError)])
 
         // Provide simple predicate that always returns true
         var attempts = 0
@@ -138,10 +138,10 @@ class RetryWithBehaviorTests: XCTestCase {
     }
 
 	func testImmediateNotRetryWithPredicate() {
-		let correctValues = [
-			next(210, 1),
-			next(220, 2),
-			error(230, RepeatTestErrors.fatalError)]
+		let correctValues = Recorded.events([
+			.next(210, 1),
+			.next(220, 2),
+			.error(230, RepeatTestErrors.fatalError)])
 
 		// Provide simple predicate that always return false (so, sequence will not repeated)
 		let res = scheduler.start(created: 0, subscribed: 0, disposed: 1000) {
@@ -154,14 +154,14 @@ class RetryWithBehaviorTests: XCTestCase {
 	}
 
 	func testDelayedRetryWithoutPredicate() {
-		let correctValues = [
-			next(210, 1),
-			next(220, 2),
-			next(445, 1),
-			next(455, 2),
-			next(680, 1),
-			next(690, 2),
-			error(700, RepeatTestErrors.fatalError)]
+		let correctValues = Recorded.events([
+			.next(210, 1),
+			.next(220, 2),
+			.next(445, 1),
+			.next(455, 2),
+			.next(680, 1),
+			.next(690, 2),
+			.error(700, RepeatTestErrors.fatalError)])
 
 		let res = scheduler.start(created: 0, subscribed: 0, disposed: 1000) {
 			self.sampleValues.asObservable().retry(.delayed(maxCount: 3, time: 5.0), scheduler: self.scheduler)
@@ -171,14 +171,14 @@ class RetryWithBehaviorTests: XCTestCase {
 	}
 
 	func testDelayedRetryWithPredicate() {
-		let correctValues = [
-			next(210, 1),
-			next(220, 2),
-			next(445, 1),
-			next(455, 2),
-			next(680, 1),
-			next(690, 2),
-			error(700, RepeatTestErrors.fatalError)]
+		let correctValues = Recorded.events([
+			.next(210, 1),
+			.next(220, 2),
+			.next(445, 1),
+			.next(455, 2),
+			.next(680, 1),
+			.next(690, 2),
+			.error(700, RepeatTestErrors.fatalError)])
 
 		let res = scheduler.start(created: 0, subscribed: 0, disposed: 1000) {
 			self.sampleValues.asObservable().retry(.delayed(maxCount: 3, time: 5.0), scheduler: self.scheduler) { _ in
@@ -190,10 +190,10 @@ class RetryWithBehaviorTests: XCTestCase {
 	}
 
 	func testDelayedNotRetryWithPredicate() {
-		let correctValues = [
-			next(210, 1),
-			next(220, 2),
-			error(230, RepeatTestErrors.fatalError)]
+		let correctValues = Recorded.events([
+			.next(210, 1),
+			.next(220, 2),
+			.error(230, RepeatTestErrors.fatalError)])
 
 		let res = scheduler.start(created: 0, subscribed: 0, disposed: 1000) {
 			self.sampleValues.asObservable().retry(.delayed(maxCount: 3, time: 5.0), scheduler: self.scheduler) { _ in
@@ -205,16 +205,16 @@ class RetryWithBehaviorTests: XCTestCase {
 	}
 
 	func testExponentialRetryWithoutPredicate() {
-		let correctValues = [
-			next(210, 1),
-			next(220, 2),
-			next(445, 1),
-			next(455, 2),
-			next(685, 1),
-			next(695, 2),
-			next(935, 1),
-			next(945, 2),
-			error(955, RepeatTestErrors.fatalError)]
+		let correctValues = Recorded.events([
+			.next(210, 1),
+			.next(220, 2),
+			.next(445, 1),
+			.next(455, 2),
+			.next(685, 1),
+			.next(695, 2),
+			.next(935, 1),
+			.next(945, 2),
+			.error(955, RepeatTestErrors.fatalError)])
 
 		let res = scheduler.start(created: 0, subscribed: 0, disposed: 1000) {
 			self.sampleValues.asObservable().retry(.exponentialDelayed(maxCount: 4, initial: 5.0, multiplier: 1.0), scheduler: self.scheduler)
@@ -224,16 +224,16 @@ class RetryWithBehaviorTests: XCTestCase {
 	}
 
 	func testExponentialRetryWithPredicate() {
-		let correctValues = [
-			next(210, 1),
-			next(220, 2),
-			next(445, 1),
-			next(455, 2),
-			next(685, 1),
-			next(695, 2),
-			next(935, 1),
-			next(945, 2),
-			error(955, RepeatTestErrors.fatalError)]
+		let correctValues = Recorded.events([
+			.next(210, 1),
+			.next(220, 2),
+			.next(445, 1),
+			.next(455, 2),
+			.next(685, 1),
+			.next(695, 2),
+			.next(935, 1),
+			.next(945, 2),
+			.error(955, RepeatTestErrors.fatalError)])
 
 		let res = scheduler.start(created: 0, subscribed: 0, disposed: 1000) {
 			self.sampleValues.asObservable().retry(.exponentialDelayed(maxCount: 4, initial: 5.0, multiplier: 1.0), scheduler: self.scheduler) { _ in
@@ -245,10 +245,10 @@ class RetryWithBehaviorTests: XCTestCase {
 	}
 
 	func testExponentialNotRetryWithPredicate() {
-		let correctValues = [
-			next(210, 1),
-			next(220, 2),
-			error(230, RepeatTestErrors.fatalError)]
+		let correctValues = Recorded.events([
+			.next(210, 1),
+			.next(220, 2),
+			.error(230, RepeatTestErrors.fatalError)])
 
 		let res = scheduler.start(created: 0, subscribed: 0, disposed: 1000) {
 			self.sampleValues.asObservable().retry(.exponentialDelayed(maxCount: 4, initial: 5.0, multiplier: 1.0), scheduler: self.scheduler) { _ in
@@ -260,26 +260,26 @@ class RetryWithBehaviorTests: XCTestCase {
 	}
 
 	func testCustomTimerRetryWithoutPredicate() {
-		let correctValues = [
-			next(210, 1),
-			next(220, 2),
-			next(450, 1),
-			next(460, 2),
-			next(710, 1),
-			next(720, 2),
-			next(990, 1),
-			next(1000, 2),
-			next(1300, 1),
-			next(1310, 2),
-			error(1320, RepeatTestErrors.fatalError)]
+		let correctValues = Recorded.events([
+			.next(210, 1),
+			.next(220, 2),
+			.next(450, 1),
+			.next(460, 2),
+			.next(710, 1),
+			.next(720, 2),
+			.next(990, 1),
+			.next(1000, 2),
+			.next(1300, 1),
+			.next(1310, 2),
+			.error(1320, RepeatTestErrors.fatalError)])
 
 		// Custom delay calculator
-		let customCalculator: (UInt) -> Double = { attempt in
+		let customCalculator: (UInt) -> DispatchTimeInterval = { attempt in
 			switch attempt {
-			case 1: return 10.0
-			case 2: return 30.0
-			case 3: return 50.0
-			default: return 80.0
+			case 1: return .seconds(10)
+			case 2: return .seconds(30)
+			case 3: return .seconds(50)
+			default: return .seconds(80)
 			}
 		}
 
@@ -291,26 +291,26 @@ class RetryWithBehaviorTests: XCTestCase {
 	}
 
 	func testCustomTimerRetryWithPredicate() {
-		let correctValues = [
-			next(210, 1),
-			next(220, 2),
-			next(450, 1),
-			next(460, 2),
-			next(710, 1),
-			next(720, 2),
-			next(990, 1),
-			next(1000, 2),
-			next(1300, 1),
-			next(1310, 2),
-			error(1320, RepeatTestErrors.fatalError)]
+		let correctValues = Recorded.events([
+			.next(210, 1),
+			.next(220, 2),
+			.next(450, 1),
+			.next(460, 2),
+			.next(710, 1),
+			.next(720, 2),
+			.next(990, 1),
+			.next(1000, 2),
+			.next(1300, 1),
+			.next(1310, 2),
+			.error(1320, RepeatTestErrors.fatalError)])
 
 		// Custom delay calculator
-		let customCalculator: (UInt) -> Double = { attempt in
+		let customCalculator: (UInt) -> DispatchTimeInterval = { attempt in
 			switch attempt {
-			case 1: return 10.0
-			case 2: return 30.0
-			case 3: return 50.0
-			default: return 80.0
+			case 1: return .seconds(10)
+			case 2: return .seconds(30)
+			case 3: return .seconds(50)
+			default: return .seconds(80)
 			}
 		}
 
@@ -324,18 +324,18 @@ class RetryWithBehaviorTests: XCTestCase {
 	}
 
 	func testCustomTimerNotRetryWithPredicate() {
-		let correctValues = [
-			next(210, 1),
-			next(220, 2),
-			error(230, RepeatTestErrors.fatalError)]
+		let correctValues = Recorded.events([
+			.next(210, 1),
+			.next(220, 2),
+			.error(230, RepeatTestErrors.fatalError)])
 
 		// Custom delay calculator
-		let customCalculator: ((UInt) -> Double) = { attempt in
+		let customCalculator: ((UInt) -> DispatchTimeInterval) = { attempt in
 			switch attempt {
-			case 1: return 10.0
-			case 2: return 30.0
-			case 3: return 50.0
-			default: return 80.0
+			case 1: return .seconds(10)
+			case 2: return .seconds(30)
+			case 3: return .seconds(500)
+			default: return .seconds(80)
 			}
 		}
 


### PR DESCRIPTION
RxSwiftExt ~4.0.0~ 5.0.0 updated to RxSwift 5.
This version will require the Swift 5 compiler (e.g. Xcode 10.2).

I think we'll skip major version 4.x so we're properly aligned with RxSwift versioning, as suggested below.