### PR TITLE
`once`: Use NSRecursiveLock instead of deprecated OSAtomicOr32OrigBarrier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Changelog
 =========
 
 - added `reachedBottom(offset:)` for `UIScrollView`
+- removed deprecated `OSAtomicOr32OrigBarrier`
 
 5.0.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Changelog
 =========
 
 - added `reachedBottom(offset:)` for `UIScrollView`
-- removed deprecated `OSAtomicOr32OrigBarrier`
+- `once` now uses a `NSRecursiveLock` instead of the deprecated `OSAtomicOr32OrigBarrier`
 
 5.0.0
 -----

--- a/Source/RxSwift/once.swift
+++ b/Source/RxSwift/once.swift
@@ -25,12 +25,15 @@ extension Observable {
 	*/
 
 	public static func once(_ element: Element) -> Observable<Element> {
-		var delivered: UInt32 = 0
+        let lock = NSRecursiveLock()
+		var isDelivered = false
 		return create { observer in
-			let wasDelivered = OSAtomicOr32OrigBarrier(1, &delivered)
-			if wasDelivered == 0 {
+			lock.lock()
+			if !isDelivered {
 				observer.onNext(element)
 			}
+            isDelivered = true
+            lock.unlock()
 			observer.onCompleted()
             return Disposables.create()
 		}


### PR DESCRIPTION
Resolve https://github.com/RxSwiftCommunity/RxSwiftExt/issues/200

@freak4pc mentioned that adding RxAtomic as dependency is an unwanted solution, so here is yet another `AtomicInt` implementation with few needed operators. Tests were just copied from `RxSwift` repo