### PR TITLE
Change `filterMap(transform:)` callback signature on throwing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Changelog
 =========
 
 - added `reachedBottom(offset:)` for `UIScrollView`
+- changed `filterMap(transform:)` callback on throwing
 
 5.0.0
 -----

--- a/RxSwiftExt.xcodeproj/project.pbxproj
+++ b/RxSwiftExt.xcodeproj/project.pbxproj
@@ -143,6 +143,9 @@
 		780CB21F20A0EE8300FD3F39 /* MapManyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 780CB21C20A0EE8300FD3F39 /* MapManyTests.swift */; };
 		78199613228449CA00340AF4 /* UIScrollView+reachedBottom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78199612228449CA00340AF4 /* UIScrollView+reachedBottom.swift */; };
 		7819961622844EF800340AF4 /* UIScrollView+reachedBottomTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7819961422844E9D00340AF4 /* UIScrollView+reachedBottomTests.swift */; };
+		7824858B22988B70005CF8CC /* TestErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7824858A22988B70005CF8CC /* TestErrors.swift */; };
+		7824858C22988B70005CF8CC /* TestErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7824858A22988B70005CF8CC /* TestErrors.swift */; };
+		7824858D22988B70005CF8CC /* TestErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7824858A22988B70005CF8CC /* TestErrors.swift */; };
 		789682E720408A7500545396 /* mapAt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CF5F8B2202D6C5F00C1BA97 /* mapAt.swift */; };
 		789682E820408A7700545396 /* mapAt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CF5F8B2202D6C5F00C1BA97 /* mapAt.swift */; };
 		8CF5F8AF202D62AB00C1BA97 /* MapAtTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CF5F8AD202D622000C1BA97 /* MapAtTests.swift */; };
@@ -353,6 +356,7 @@
 		780CB21C20A0EE8300FD3F39 /* MapManyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapManyTests.swift; sourceTree = "<group>"; };
 		78199612228449CA00340AF4 /* UIScrollView+reachedBottom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView+reachedBottom.swift"; sourceTree = "<group>"; };
 		7819961422844E9D00340AF4 /* UIScrollView+reachedBottomTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView+reachedBottomTests.swift"; sourceTree = "<group>"; };
+		7824858A22988B70005CF8CC /* TestErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestErrors.swift; sourceTree = "<group>"; };
 		8CF5F8AD202D622000C1BA97 /* MapAtTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapAtTests.swift; sourceTree = "<group>"; };
 		8CF5F8B2202D6C5F00C1BA97 /* mapAt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = mapAt.swift; sourceTree = "<group>"; };
 		98309EAE1EDF14AC00BD07D9 /* flatMapSync.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = flatMapSync.swift; path = Source/RxSwift/flatMapSync.swift; sourceTree = SOURCE_ROOT; };
@@ -485,6 +489,7 @@
 				3DB034F61DC376D9002C6A26 /* Info.plist */,
 				538607701E6F1C38000361DE /* RxCocoa */,
 				538607BA1E6F362B000361DE /* RxSwift */,
+				7824858A22988B70005CF8CC /* TestErrors.swift */,
 			);
 			name = Tests;
 			sourceTree = "<group>";
@@ -1065,6 +1070,7 @@
 				53F336EA1E70D59000D35D38 /* DistinctTests+RxCocoa.swift in Sources */,
 				98309EB41EDF167300BD07D9 /* FilterMapTests.swift in Sources */,
 				B69B454E2190C3CC00F30418 /* CountTests.swift in Sources */,
+				7824858B22988B70005CF8CC /* TestErrors.swift in Sources */,
 				6662395E1E9E0950009BB134 /* Materialized+elementsTests.swift in Sources */,
 				538607E81E6F36A9000361DE /* NotTests.swift in Sources */,
 				BF515CE51F3F3AF400492640 /* FromAsyncTests.swift in Sources */,
@@ -1180,6 +1186,7 @@
 				62512C921F0EB1850083A89F /* ApplyTests.swift in Sources */,
 				62512CA21F0EB1850083A89F /* WeakTarget.swift in Sources */,
 				62512C9D1F0EB1850083A89F /* PausableTests.swift in Sources */,
+				7824858C22988B70005CF8CC /* TestErrors.swift in Sources */,
 				62512C991F0EB1850083A89F /* MapToTests.swift in Sources */,
 				3DBDE6001FBBB09A00DF47F9 /* AndTests.swift in Sources */,
 				58C54302EC14B6FF2034BAF6 /* ZipWithTest.swift in Sources */,
@@ -1265,6 +1272,7 @@
 				E39C420D1F18B13E007F2ACD /* RepeatWithBehaviorTests.swift in Sources */,
 				E39C42091F18B13E007F2ACD /* NotTests.swift in Sources */,
 				E39C42081F18B13E007F2ACD /* Materialized+elementsTests.swift in Sources */,
+				7824858D22988B70005CF8CC /* TestErrors.swift in Sources */,
 				E39C42071F18B13E007F2ACD /* MapToTests.swift in Sources */,
 				3DBDE6011FBBB09A00DF47F9 /* AndTests.swift in Sources */,
 				58C54B6E1B4C678DE2378145 /* ZipWithTest.swift in Sources */,

--- a/Source/RxSwift/filterMap.swift
+++ b/Source/RxSwift/filterMap.swift
@@ -21,15 +21,14 @@ public enum FilterMap<Result> {
 }
 
 extension ObservableType {
-
     /**
      Filters or Maps values from the source.
-     - The returned Observable will error and complete with the source.
+     - The returned Observable will complete with the source. It will error with the source or with error thrown by transform callback.
      - `next` values will be output according to the `transform` callback result:
         - returning `.ignore` will filter the value out of the returned Observable
         - returning `.map(newValue)` will propagate newValue through the returned Observable.
      */
-    public func filterMap<Result>(_ transform: @escaping (Element) -> FilterMap<Result>) -> Observable<Result> {
-        return flatMapSync { transform($0).asOperator }
+    public func filterMap<Result>(_ transform: @escaping (Element) throws -> FilterMap<Result>) -> Observable<Result> {
+        return flatMapSync { try transform($0).asOperator }
     }
 }

--- a/TestErrors.swift
+++ b/TestErrors.swift
@@ -1,0 +1,12 @@
+//
+//  TestErrors.swift
+//  RxSwiftExt
+//
+//  Created by Anton Nazarov on 24/05/2019.
+//  Copyright © 2019 RxSwiftCommunity. All rights reserved.
+//
+
+enum TestError: Error {
+    case dummyError
+}
+let testError = TestError.dummyError


### PR DESCRIPTION
Based on https://github.com/RxSwiftCommunity/RxSwiftExt/pull/185