### PR TITLE
Added `mapTo` for `Single` and `Maybe`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog
 - `once` now uses a `NSRecursiveLock` instead of the deprecated `OSAtomicOr32OrigBarrier`
 - added `merge(with:)` for `Observable`
 - removed `flatMapSync` operator
+- added `mapTo` for `Single` and `Maybe`
 
 5.0.0
 -----

--- a/Source/RxSwift/mapTo.swift
+++ b/Source/RxSwift/mapTo.swift
@@ -17,7 +17,31 @@ extension ObservableType {
 	- parameter value: A constant that each element of the input sequence is being replaced with
 	- returns: An observable sequence containing the values `value` provided as a parameter
 	*/
-	public func mapTo<R>(_ value: R) -> Observable<R> {
+	public func mapTo<Result>(_ value: Result) -> Observable<Result> {
 		return map { _ in value }
 	}
+}
+
+extension PrimitiveSequence where Trait == SingleTrait {
+    /**
+     Returns a Single which success event is mapped to constant provided as a parameter
+
+     - parameter value: A constant that element of the input sequence is being replaced with
+     - returns: A Single containing the value `value` provided as a parameter in case of success
+     */
+    public func mapTo<Result>(_ value: Result) -> Single<Result> {
+        return map { _ in value }
+    }
+}
+
+extension PrimitiveSequence where Trait == MaybeTrait {
+    /**
+     Returns a Maybe which success event is mapped to constant provided as a parameter
+
+     - parameter value: A constant that element of the input sequence is being replaced with
+     - returns: A Maybe containing the value `value` provided as a parameter in case of success
+     */
+    public func mapTo<Result>(_ value: Result) -> Maybe<Result> {
+        return map { _ in value }
+    }
 }

--- a/Tests/RxSwift/mapToTests.swift
+++ b/Tests/RxSwift/mapToTests.swift
@@ -14,7 +14,7 @@ import RxTest
 
 class MapToTests: XCTestCase {
 
-    let numbers: [Int?] = [1, nil, Int?(3)]
+    private let numbers: [Int?] = [1, nil, Int?(3)]
     private var observer: TestableObserver<String>!
 
     override func setUp() {
@@ -46,5 +46,79 @@ class MapToTests: XCTestCase {
             .completed(0)
         ])
         XCTAssertEqual(observer.events, correctValues)
+    }
+}
+
+// MARK: - Single
+extension MapToTests {
+    func testSingleReplaceSuccess() {
+        // Given
+        let expectedValue = "candy"
+        let scheduler = TestScheduler(initialClock: 0)
+        observer = scheduler.createObserver(String.self)
+        // When
+        let result = scheduler.start {
+            Single.just(1).mapTo(expectedValue).asObservable()
+        }
+        // Then
+        XCTAssertEqual(result.events, [
+            .next(TestScheduler.Defaults.subscribed, expectedValue),
+            .completed(TestScheduler.Defaults.subscribed)
+        ])
+    }
+
+    func testSingleNoReplaceFailure() {
+        // Given
+        let scheduler = TestScheduler(initialClock: 0)
+        observer = scheduler.createObserver(String.self)
+        // When
+        let result = scheduler.start {
+            Single<Int>.error(testError).mapTo("candy").asObservable()
+        }
+        // Then
+        XCTAssertEqual(result.events, [.error(TestScheduler.Defaults.subscribed, testError)])
+    }
+}
+
+// MARK: - Maybe
+extension MapToTests {
+    func testMaybeReplaceSuccess() {
+        // Given
+        let expectedValue = "candy"
+        let scheduler = TestScheduler(initialClock: 0)
+        observer = scheduler.createObserver(String.self)
+        // When
+        let result = scheduler.start {
+            Maybe.just(1).mapTo(expectedValue).asObservable()
+        }
+        // Then
+        XCTAssertEqual(result.events, [
+            .next(TestScheduler.Defaults.subscribed, expectedValue),
+            .completed(TestScheduler.Defaults.subscribed)
+        ])
+    }
+
+    func testMaybeNoReplaceFailure() {
+        // Given
+        let scheduler = TestScheduler(initialClock: 0)
+        observer = scheduler.createObserver(String.self)
+        // When
+        let result = scheduler.start {
+            Maybe<Int>.error(testError).mapTo("candy").asObservable()
+        }
+        // Then
+        XCTAssertEqual(result.events, [.error(TestScheduler.Defaults.subscribed, testError)])
+    }
+
+    func testMaybeNoReplaceEmpty() {
+        // Given
+        let scheduler = TestScheduler(initialClock: 0)
+        observer = scheduler.createObserver(String.self)
+        // When
+        let result = scheduler.start {
+            Maybe<Int>.empty().mapTo("candy").asObservable()
+        }
+        // Then
+        XCTAssertEqual(result.events, [.completed(TestScheduler.Defaults.subscribed)])
     }
 }

--- a/Tests/RxSwift/mapToTests.swift
+++ b/Tests/RxSwift/mapToTests.swift
@@ -55,7 +55,6 @@ extension MapToTests {
         // Given
         let expectedValue = "candy"
         let scheduler = TestScheduler(initialClock: 0)
-        observer = scheduler.createObserver(String.self)
         // When
         let result = scheduler.start {
             Single.just(1).mapTo(expectedValue).asObservable()
@@ -70,7 +69,6 @@ extension MapToTests {
     func testSingleNoReplaceFailure() {
         // Given
         let scheduler = TestScheduler(initialClock: 0)
-        observer = scheduler.createObserver(String.self)
         // When
         let result = scheduler.start {
             Single<Int>.error(testError).mapTo("candy").asObservable()
@@ -86,7 +84,6 @@ extension MapToTests {
         // Given
         let expectedValue = "candy"
         let scheduler = TestScheduler(initialClock: 0)
-        observer = scheduler.createObserver(String.self)
         // When
         let result = scheduler.start {
             Maybe.just(1).mapTo(expectedValue).asObservable()
@@ -101,7 +98,6 @@ extension MapToTests {
     func testMaybeNoReplaceFailure() {
         // Given
         let scheduler = TestScheduler(initialClock: 0)
-        observer = scheduler.createObserver(String.self)
         // When
         let result = scheduler.start {
             Maybe<Int>.error(testError).mapTo("candy").asObservable()
@@ -113,7 +109,6 @@ extension MapToTests {
     func testMaybeNoReplaceEmpty() {
         // Given
         let scheduler = TestScheduler(initialClock: 0)
-        observer = scheduler.createObserver(String.self)
         // When
         let result = scheduler.start {
             Maybe<Int>.empty().mapTo("candy").asObservable()


### PR DESCRIPTION
There was a discussion in RxSwift slack, that few handy operators are implemented only for `Observable`. This PR adds `.mapTo` for Single and Maybe.
I have a few prod examples when I don't interested in `Single` actual result, however, I can't use `Completable`.

```swift
let single: Single<Model> = service.get().share()
single.subscribe(onSuccess: { *interested in success value* })
single.mapTo(true).bind(to: subject) // not interested in success value
```
