### PR TITLE
Add `apply` for Single, Maybe & Completable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog
 - `once` now uses a `NSRecursiveLock` instead of the deprecated `OSAtomicOr32OrigBarrier`
 - added `merge(with:)` for `Observable`
 - removed `flatMapSync` operator
+- added `apply` for `Completable` and `Maybe` 
 
 5.0.0
 -----

--- a/Source/RxSwift/apply.swift
+++ b/Source/RxSwift/apply.swift
@@ -16,9 +16,10 @@ extension ObservableType {
     }
 }
 
-extension PrimitiveSequenceType where Trait == SingleTrait {
-    /// Apply a transformation function to the Single.
-    public func apply<T>(_ transform: (Single<Element>) -> Single<T>) -> Single<T> {
+extension PrimitiveSequenceType {
+    /// Apply a transformation function to the primitive sequence.
+    public func apply<Result>(_ transform: (PrimitiveSequence<Trait, Element>) -> PrimitiveSequence<Trait, Result>)
+        -> PrimitiveSequence<Trait, Result> {
         return transform(self.primitiveSequence)
     }
 }


### PR DESCRIPTION
Same motivation with `Single.apply`. I have network layer and basic policy (retry, network activity indicator, logging etc.) which I want to apply to all my requests (which can be `Single`, `Maybe` and `Completable`)