### PR TITLE
Fix typos across RxSwiftExt repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog
 - `once` now uses a `NSRecursiveLock` instead of the deprecated `OSAtomicOr32OrigBarrier`
 - added `merge(with:)` for `Observable`
 - removed `flatMapSync` operator
+- Fix typos across RxSwiftExt repository
 
 5.0.0
 -----

--- a/Readme.md
+++ b/Readme.md
@@ -465,7 +465,7 @@ The sequence above keeps even numbers 2, 4, 6 and produces the sequence 4, 8, 12
 
 #### errors, elements
 
-These operators only apply to observable serquences that have been materialized with the `materialize()` operator (from RxSwift core). `errors` returns a sequence of filtered error events, ommitting elements. `elements` returns a sequence of filtered element events, ommitting errors.
+These operators only apply to observable serquences that have been materialized with the `materialize()` operator (from RxSwift core). `errors` returns a sequence of filtered error events, omitting elements. `elements` returns a sequence of filtered element events, omitting errors.
 
 ```swift
 let imageResult = _chooseImageButtonPressed.asObservable()

--- a/Source/RxCocoa/UIScrollView+reachedBottom.swift
+++ b/Source/RxCocoa/UIScrollView+reachedBottom.swift
@@ -13,7 +13,7 @@ import RxCocoa
 public extension Reactive where Base: UIScrollView {
     /**
      Shows if the bottom of the UIScrollView is reached.
-     - parameter offset: A threshhold indicating the bottom of the UIScrollView.
+     - parameter offset: A threshold indicating the bottom of the UIScrollView.
      - returns: ControlEvent that emits when the bottom of the base UIScrollView is reached.
      */
     func reachedBottom(offset: CGFloat = 0.0) -> ControlEvent<Void> {

--- a/Source/RxSwift/retryWithBehavior.swift
+++ b/Source/RxSwift/retryWithBehavior.swift
@@ -11,7 +11,7 @@ import RxSwift
 
 /**
 Specifies how observable sequence will be repeated in case of an error
-- Immediate: Will be immediatelly repeated specified number of times
+- Immediate: Will be immediately repeated specified number of times
 - Delayed: Will be repeated after specified delay specified number of times
 - ExponentialDelayed: Will be repeated specified number of times. 
 Delay will be incremented by multiplier after each iteration (multiplier = 0.5 means 50% increment)


### PR DESCRIPTION
:blue_heart: Fix typos across **RxSwiftExt** repository

### Fixed files :wrench: 

<details><summary>See all fixed files</summary>
<p>

```
RxSwiftExt/Readme.md:468:189: "ommitting" is a misspelling of "omitting"
RxSwiftExt/Readme.md:468:267: "ommitting" is a misspelling of "omitting"
RxSwiftExt/Source/RxCocoa/UIScrollView+reachedBottom.swift:16:27: "threshhold" is a misspelling of "threshold"
RxSwiftExt/Source/RxSwift/retryWithBehavior.swift:14:21: "immediatelly" is a misspelling of "immediately"
```

</p>
</details>

**FYI:** I used [**Go Spellchecker**](https://github.com/liamzdenek/go-spellcheck) :smile_cat: