### PR TITLE
Deprecate filterMap

### DIFF
--- a/Source/RxSwift/filterMap.swift
+++ b/Source/RxSwift/filterMap.swift
@@ -22,7 +22,7 @@ extension ObservableType {
         - returning `.ignore` will filter the value out of the returned Observable
         - returning `.map(newValue)` will propagate newValue through the returned Observable.
      */
-    @available(*, deprecated, renamed: "compactMap", message: "compactMap was added to the main RxSwift repository and should be used instead of filterMap")
+    @available(*, deprecated, renamed: "compactMap", message: "Use compactMap instead")
     public func filterMap<Result>(_ transform: @escaping (Element) throws -> FilterMap<Result>) -> Observable<Result> {
         return flatMap { element -> Observable<Result> in
             switch try transform(element) {

--- a/Source/RxSwift/filterMap.swift
+++ b/Source/RxSwift/filterMap.swift
@@ -22,6 +22,7 @@ extension ObservableType {
         - returning `.ignore` will filter the value out of the returned Observable
         - returning `.map(newValue)` will propagate newValue through the returned Observable.
      */
+    @available(*, deprecated, renamed: "compactMap", message: "compactMap was added to the main RxSwift repository and should be used instead of filterMap")
     public func filterMap<Result>(_ transform: @escaping (Element) throws -> FilterMap<Result>) -> Observable<Result> {
         return flatMap { element -> Observable<Result> in
             switch try transform(element) {


### PR DESCRIPTION
```swift
.compactMap { predicate($0) ?$0 : nil }
// prefered over
.filterMap { predicate($0)  ? .map($0) : nil }
```