### PR TITLE
Avoid using force-unwraps of Optionals during .unwrap()

### DIFF
--- a/Source/RxSwift/unwrap.swift
+++ b/Source/RxSwift/unwrap.swift
@@ -18,6 +18,6 @@ extension ObservableType {
      */
 
     public func unwrap<T>() -> Observable<T> where Element == T? {
-        return self.filter { $0 != nil }.map { $0! }
+        return self.flatMap(Observable.from(optional:))
     }
 }


### PR DESCRIPTION
#trivial