### PR TITLE
Change unwrap impl to use compactMap

### DIFF
--- a/Source/RxSwift/unwrap.swift
+++ b/Source/RxSwift/unwrap.swift
@@ -18,6 +18,6 @@ extension ObservableType {
      */
 
     public func unwrap<T>() -> Observable<T> where Element == T? {
-        return self.filter { $0 != nil }.map { $0! }
+        return self.compactMap { $0 }
     }
 }


### PR DESCRIPTION
Based on https://github.com/RxSwiftCommunity/RxSwiftExt/pull/229 sadly can't push changes there