### PR TITLE
Reduce one character generics usage #trivial

### DIFF
--- a/Source/RxCocoa/mapTo+RxCocoa.swift
+++ b/Source/RxCocoa/mapTo+RxCocoa.swift
@@ -15,12 +15,12 @@ extension SharedSequenceConvertibleType {
      - parameter value: A constant that each element of the input sequence is being replaced with
      - returns: An unit containing the values `value` provided as a parameter
      */
-    public func mapTo<R>(_ value: R) -> SharedSequence<SharingStrategy, R> {
+    public func mapTo<Result>(_ value: Result) -> SharedSequence<SharingStrategy, Result> {
         return map { _ in value }
     }
 
     @available(*, deprecated, renamed: "mapTo(_:)")
-    public func map<R>(to value: R) -> SharedSequence<SharingStrategy, R> {
+    public func map<Result>(to value: Result) -> SharedSequence<SharingStrategy, Result> {
         return map { _ in value }
     }
 }

--- a/Source/RxCocoa/unwrap+SharedSequence.swift
+++ b/Source/RxCocoa/unwrap+SharedSequence.swift
@@ -16,7 +16,7 @@ extension SharedSequence {
      - returns: A SharedSequence of non-optional elements
      */
 
-    public func unwrap<T>() -> SharedSequence<SharingStrategy, T> where Element == T? {
+    public func unwrap<Result>() -> SharedSequence<SharingStrategy, Result> where Element == Result? {
         return self.filter { $0 != nil }.map { $0! }
     }
 }

--- a/Source/RxSwift/ObservableType+Weak.swift
+++ b/Source/RxSwift/ObservableType+Weak.swift
@@ -16,14 +16,14 @@ extension ObservableType {
 	- parameter obj:    The object that owns the function
 	- parameter method: The instance function represented as `InstanceType.instanceFunc`
 	*/
-	fileprivate func weakify<A: AnyObject, B>(_ obj: A, method: ((A) -> (B) -> Void)?) -> ((B) -> Void) {
+	fileprivate func weakify<Object: AnyObject, Input>(_ obj: Object, method: ((Object) -> (Input) -> Void)?) -> ((Input) -> Void) {
 		return { [weak obj] value in
 			guard let obj = obj else { return }
 			method?(obj)(value)
 		}
 	}
 
-    fileprivate func weakify<A: AnyObject>(_ obj: A, method: ((A) -> () -> Void)?) -> (() -> Void) {
+    fileprivate func weakify<Object: AnyObject>(_ obj: Object, method: ((Object) -> () -> Void)?) -> (() -> Void) {
         return { [weak obj] in
             guard let obj = obj else { return }
             method?(obj)()
@@ -37,7 +37,7 @@ extension ObservableType {
 	- parameter on: Function to invoke on `weak` for each event in the observable sequence.
 	- returns: Subscription object used to unsubscribe from the observable sequence.
 	*/
-	public func subscribe<A: AnyObject>(weak obj: A, _ on: @escaping (A) -> (Event<Element>) -> Void) -> Disposable {
+	public func subscribe<Object: AnyObject>(weak obj: Object, _ on: @escaping (Object) -> (Event<Element>) -> Void) -> Disposable {
 		return self.subscribe(weakify(obj, method: on))
 	}
 
@@ -52,13 +52,13 @@ extension ObservableType {
 	gracefully completed, errored, or if the generation is cancelled by disposing subscription)
 	- returns: Subscription object used to unsubscribe from the observable sequence.
 	*/
-	public func subscribe<A: AnyObject>(
-                    weak obj: A,
-                    onNext: ((A) -> (Element) -> Void)? = nil,
-                    onError: ((A) -> (Error) -> Void)? = nil,
-                    onCompleted: ((A) -> () -> Void)? = nil,
-                    onDisposed: ((A) -> () -> Void)? = nil)
-        -> Disposable {
+    public func subscribe<Object: AnyObject>(
+        weak obj: Object,
+        onNext: ((Object) -> (Element) -> Void)? = nil,
+        onError: ((Object) -> (Error) -> Void)? = nil,
+        onCompleted: ((Object) -> () -> Void)? = nil,
+        onDisposed: ((Object) -> () -> Void)? = nil
+    ) -> Disposable {
 		let disposable: Disposable
 
 		if let disposed = onDisposed {
@@ -91,7 +91,7 @@ extension ObservableType {
 	- parameter onNext: Function to invoke on `weak` for each element in the observable sequence.
 	- returns: Subscription object used to unsubscribe from the observable sequence.
 	*/
-	public func subscribeNext<A: AnyObject>(weak obj: A, _ onNext: @escaping (A) -> (Element) -> Void) -> Disposable {
+	public func subscribeNext<Object: AnyObject>(weak obj: Object, _ onNext: @escaping (Object) -> (Element) -> Void) -> Disposable {
         return self.subscribe(onNext: weakify(obj, method: onNext))
 	}
 
@@ -102,7 +102,7 @@ extension ObservableType {
 	- parameter onError: Function to invoke on `weak` upon errored termination of the observable sequence.
 	- returns: Subscription object used to unsubscribe from the observable sequence.
 	*/
-	public func subscribeError<A: AnyObject>(weak obj: A, _ onError: @escaping (A) -> (Error) -> Void) -> Disposable {
+	public func subscribeError<Object: AnyObject>(weak obj: Object, _ onError: @escaping (Object) -> (Error) -> Void) -> Disposable {
         return self.subscribe(onError: weakify(obj, method: onError))
 	}
 
@@ -113,7 +113,7 @@ extension ObservableType {
 	- parameter onCompleted: Function to invoke on `weak` graceful termination of the observable sequence.
 	- returns: Subscription object used to unsubscribe from the observable sequence.
 	*/
-	public func subscribeCompleted<A: AnyObject>(weak obj: A, _ onCompleted: @escaping (A) -> () -> Void) -> Disposable {
+	public func subscribeCompleted<Object: AnyObject>(weak obj: Object, _ onCompleted: @escaping (Object) -> () -> Void) -> Disposable {
         return self.subscribe(onCompleted: weakify(obj, method: onCompleted))
 	}
 }

--- a/Source/RxSwift/and.swift
+++ b/Source/RxSwift/and.swift
@@ -51,7 +51,8 @@ extension ObservableType where Element == Bool {
 
 	Use `asSingle()` or `asObservable()` to convert to your requirements.
 	*/
-	public static func and<C: Collection>(_ collection: C) -> Maybe<Element> where C.Element: ObservableType, C.Element.Element == Element {
+    public static func and<Collection: Swift.Collection>(_ collection: Collection)
+        -> Maybe<Element> where Collection.Element: ObservableType, Collection.Element.Element == Element {
 		return Maybe.create { observer in
 			var emitted = [Bool](repeating: false, count: Int(collection.count))
 			var completed = 0
@@ -99,7 +100,7 @@ extension ObservableType where Element == Bool {
 
 	Use `asSingle()` or `asObservable()` to convert to your requirements.
 	*/
-	public static func and<O: ObservableType>(_ sources: O ...) -> Maybe<Element> where O.Element == Element {
+	public static func and<Observable: ObservableType>(_ sources: Observable ...) -> Maybe<Element> where Observable.Element == Element {
 		return and(sources)
 	}
 }

--- a/Source/RxSwift/bufferWithTrigger.swift
+++ b/Source/RxSwift/bufferWithTrigger.swift
@@ -16,7 +16,7 @@ extension ObservableType {
      - parameter trigger: The observable sequence used to signal the emission of the buffered items.
      - returns: The buffered observable from elements of the source sequence.
      */
-    public func bufferWithTrigger<U>(_ trigger: Observable<U>) -> Observable<[Element]> {
+    public func bufferWithTrigger<Trigger: ObservableType>(_ trigger: Trigger) -> Observable<[Element]> {
         return Observable.create { observer in
             var buffer: [Element] = []
             let lock = NSRecursiveLock()

--- a/Source/RxSwift/cascade.swift
+++ b/Source/RxSwift/cascade.swift
@@ -20,7 +20,7 @@ extension Observable where Element: ObservableType {
 	- parameter observables: a sequence of observables which will all be immediately subscribed to
 	- returns: An observable sequence that contains elements from the latest observable sequence that emitted elements
 	*/
-	public static func cascade<S: Sequence>(_ observables: S) -> Observable<Element.Element> where S.Element == Element {
+    public static func cascade<Sequebce: Swift.Sequence>(_ observables: Sequebce) -> Observable<Element.Element> where Sequebce.Element == Element {
         let flow = Array(observables)
         if flow.isEmpty {
             return Observable<Element.Element>.empty()

--- a/Source/RxSwift/cascade.swift
+++ b/Source/RxSwift/cascade.swift
@@ -20,7 +20,7 @@ extension Observable where Element: ObservableType {
 	- parameter observables: a sequence of observables which will all be immediately subscribed to
 	- returns: An observable sequence that contains elements from the latest observable sequence that emitted elements
 	*/
-    public static func cascade<Sequebce: Swift.Sequence>(_ observables: Sequebce) -> Observable<Element.Element> where Sequebce.Element == Element {
+    public static func cascade<Sequence: Swift.Sequence>(_ observables: Sequence) -> Observable<Element.Element> where Sequence.Element == Element {
         let flow = Array(observables)
         if flow.isEmpty {
             return Observable<Element.Element>.empty()

--- a/Source/RxSwift/ofType.swift
+++ b/Source/RxSwift/ofType.swift
@@ -19,9 +19,9 @@ extension ObservableType {
      - parameter type: The Type to filter each source element.
      - returns: An observable sequence that contains elements which is an instance of the suppplied type.
      */
-    public func ofType<T>(_ type: T.Type) -> Observable<T> {
+    public func ofType<Result>(_ type: Result.Type) -> Observable<Result> {
         return self.filterMap {
-            guard let result = $0 as? T else { return .ignore }
+            guard let result = $0 as? Result else { return .ignore }
             return .map(result)
         }
     }

--- a/Source/RxSwift/pausable.swift
+++ b/Source/RxSwift/pausable.swift
@@ -21,7 +21,7 @@ extension ObservableType {
 	- returns: The observable sequence which is paused based upon the pauser observable sequence.
 	*/
 
-    public func pausable<P: ObservableType> (_ pauser: P) -> Observable<Element> where P.Element == Bool {
+    public func pausable<Pauser: ObservableType> (_ pauser: Pauser) -> Observable<Element> where Pauser.Element == Bool {
 		return withLatestFrom(pauser) { element, paused in
 				(element, paused)
 			}

--- a/Source/RxSwift/pausableBuffered.swift
+++ b/Source/RxSwift/pausableBuffered.swift
@@ -26,7 +26,7 @@ extension ObservableType {
      - parameter flushOnError: If `true` buffered elements will be flushed when the source errors. Default `true`.
      - returns: The observable sequence which is paused and resumed based upon the pauser observable sequence.
      */
-    public func pausableBuffered<P: ObservableType> (_ pauser: P, limit: Int? = 1, flushOnCompleted: Bool = true, flushOnError: Bool = true) -> Observable<Element> where P.Element == Bool {
+    public func pausableBuffered<Pauser: ObservableType> (_ pauser: Pauser, limit: Int? = 1, flushOnCompleted: Bool = true, flushOnError: Bool = true) -> Observable<Element> where Pauser.Element == Bool {
 
         return Observable<Element>.create { observer in
             var buffer: [Element] = []

--- a/Source/RxSwift/unwrap.swift
+++ b/Source/RxSwift/unwrap.swift
@@ -17,7 +17,7 @@ extension ObservableType {
      - returns: An observable sequence of non-optional elements
      */
 
-    public func unwrap<T>() -> Observable<T> where Element == T? {
+    public func unwrap<Result>() -> Observable<Result> where Element == Result? {
         return self.compactMap { $0 }
     }
 }

--- a/Source/RxSwift/withUnretained.swift
+++ b/Source/RxSwift/withUnretained.swift
@@ -17,8 +17,8 @@ extension ObservableType {
      - parameter resultSelector: A function to combine the unretained referenced on `obj` and the value of the observable sequence.
      - returns: An observable sequence that contains the result of `resultSelector` being called with an unretained reference on `obj` and the values of the original sequence.
      */
-    public func withUnretained<T: AnyObject, Out>(_ obj: T,
-                                                  resultSelector: @escaping ((T, Element)) -> Out) -> Observable<Out> {
+    public func withUnretained<Object: AnyObject, Out>(_ obj: Object,
+                                                  resultSelector: @escaping ((Object, Element)) -> Out) -> Observable<Out> {
         return map { [weak obj] element -> Out in
             guard let obj = obj else { throw UnretainedError.failedRetaining }
 
@@ -41,7 +41,7 @@ extension ObservableType {
      - parameter obj: The object to provide an unretained reference on.
      - returns: An observable sequence of tuples that contains both an unretained reference on `obj` and the values of the original sequence.
      */
-    public func withUnretained<T: AnyObject>(_ obj: T) -> Observable<(T, Element)> {
+    public func withUnretained<Object: AnyObject>(_ obj: Object) -> Observable<(Object, Element)> {
         return withUnretained(obj) { ($0, $1) }
     }
 }

--- a/Source/RxSwift/zipWith.swift
+++ b/Source/RxSwift/zipWith.swift
@@ -21,7 +21,7 @@ extension ObservableConvertibleType {
 
      - Returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
      */
-    public func zip<O2, ResultType>(with second: O2, resultSelector: @escaping (Element, O2.Element) throws -> ResultType) -> Observable<ResultType> where O2: ObservableConvertibleType {
+    public func zip<Observable2: ObservableConvertibleType, ResultType>(with second: Observable2, resultSelector: @escaping (Element, Observable2.Element) throws -> ResultType) -> Observable<ResultType> {
         return Observable.zip(asObservable(), second.asObservable(), resultSelector: resultSelector)
     }
 }

--- a/Source/RxSwift/zipWith.swift
+++ b/Source/RxSwift/zipWith.swift
@@ -21,7 +21,7 @@ extension ObservableConvertibleType {
 
      - Returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
      */
-    public func zip<Observable2: ObservableConvertibleType, ResultType>(with second: Observable2, resultSelector: @escaping (Element, Observable2.Element) throws -> ResultType) -> Observable<ResultType> {
+    public func zip<Other: ObservableConvertibleType, ResultType>(with second: Other, resultSelector: @escaping (Element, Other.Element) throws -> ResultType) -> Observable<ResultType> {
         return Observable.zip(asObservable(), second.asObservable(), resultSelector: resultSelector)
     }
 }


### PR DESCRIPTION
It's better for readability to avoid one character generics naming. RxSwift already replaced all generics to meaningful title, it's RxSwiftExt turn

P.S. lol, i found that project uses tabs as indents. I am not sure, should i indent new code with tabs or spaces