### PR TITLE
Remove dublicated test errors #trivial

### DIFF
--- a/Tests/RxSwift/MergeWithTests.swift
+++ b/Tests/RxSwift/MergeWithTests.swift
@@ -10,9 +10,6 @@ import XCTest
 import RxSwift
 import RxTest
 
-enum MergeWithError: Error {
-    case error
-}
 
 class MergeWithTests: XCTestCase {
     fileprivate func runAndObserve<T>(_ sequence: Observable<T>) -> TestableObserver<T> {
@@ -67,11 +64,11 @@ class MergeWithTests: XCTestCase {
 
     func testMergeWith_Error() {
         let numberStream = Observable.from([1, 2, 3, 4])
-        let errorStream = Observable<Int>.error(MergeWithError.error)
+        let errorStream = Observable<Int>.error(testError)
 
         let observer = runAndObserve(numberStream.merge(with: errorStream))
 
-        let expected = Recorded<Event<Int>>.events([.error(0, MergeWithError.error)])
+        let expected = Recorded<Event<Int>>.events([.error(0, testError)])
 
         XCTAssertEqual(observer.events, expected)
     }

--- a/Tests/RxSwift/Observable+OfTypeTests.swift
+++ b/Tests/RxSwift/Observable+OfTypeTests.swift
@@ -14,14 +14,8 @@ import RxTest
 #if os(Linux)
     import Glibc
 #endif
-class ObservableOfTypeTest: XCTestCase {
-    enum TestError: Error {
-        case dummyError
-    }
-    let testError = TestError.dummyError
-}
 
-extension ObservableOfTypeTest {
+class ObservableOfTypeTest {
     func test_ofTypeComplete() {
         let scheduler = TestScheduler(initialClock: 0)
 

--- a/Tests/RxSwift/WeakTarget.swift
+++ b/Tests/RxSwift/WeakTarget.swift
@@ -9,9 +9,6 @@
 import Foundation
 import RxSwift
 
-enum WeakTargetError: Error {
-    case error
-}
 enum RxEvent {
     case next, error, completed, disposed
     init<T>(event: Event<T>) {

--- a/Tests/RxSwift/WeakTests.swift
+++ b/Tests/RxSwift/WeakTests.swift
@@ -44,7 +44,7 @@ class WeakTests: XCTestCase {
         self.source.onNext(0)
         self.target = nil
         self.source.onNext(0)
-        self.source.onError(WeakTargetError.error)
+        self.source.onError(testError)
         self.target?.dispose()
 
         let expected: [RxEvent: Int] = [.next: 2, .error: 0, .completed: 0, .disposed: 0]
@@ -68,7 +68,7 @@ class WeakTests: XCTestCase {
     func testSubscribeError() {
         self.target?.useSubscribeError()
 
-        self.source.onError(WeakTargetError.error)
+        self.source.onError(testError)
         self.target = nil
 
         // Errors only emit once
@@ -104,7 +104,7 @@ class WeakTests: XCTestCase {
     func testSubscribeOn_Error() {
         self.target?.useSubscribeMulti()
 
-        self.source.onError(WeakTargetError.error)
+        self.source.onError(testError)
         self.target = nil
 
         // Errors only emit once

--- a/Tests/RxSwift/ZipWithTest.swift
+++ b/Tests/RxSwift/ZipWithTest.swift
@@ -15,10 +15,6 @@ struct Pair<F: Equatable, S: Equatable> {
     let second: S
 }
 
-enum ZipWithTestError: Error {
-    case error
-}
-
 extension Pair: Equatable {
 }
 
@@ -65,7 +61,7 @@ class ZipWithTest: XCTestCase {
     func testZipWith_SourceError_ZipCompletesWithError() {
         let scheduler = TestScheduler(initialClock: 0)
         let source1 = Observable.just(1)
-        let source2 = Observable<Int>.error(ZipWithTestError.error)
+        let source2 = Observable<Int>.error(testError)
 
         let res = scheduler.start {
             source1.zip(with: source2) {
@@ -73,7 +69,7 @@ class ZipWithTest: XCTestCase {
             }
         }
 
-        let expected: [Recorded<Event<Pair<Int, Int>>>] = [.error(200, ZipWithTestError.error)]
+        let expected: [Recorded<Event<Pair<Int, Int>>>] = [.error(200, testError)]
         XCTAssertEqual(res.events, expected)
     }
 

--- a/Tests/RxSwift/andTests.swift
+++ b/Tests/RxSwift/andTests.swift
@@ -10,9 +10,6 @@ import XCTest
 import RxSwift
 import RxTest
 
-private enum AndTestsError: Error {
-	case anyError
-}
 
 class AndTests: XCTestCase {
 	fileprivate func runAndObserve(_ sequence: Maybe<Bool>) -> TestableObserver<Bool> {
@@ -95,10 +92,10 @@ class AndTests: XCTestCase {
 	}
 
 	func testSingle_onlyError() {
-		let source = Observable<Bool>.error(AndTestsError.anyError)
+		let source = Observable<Bool>.error(testError)
 		let observer = runAndObserve(source.and())
 		let correct: [Recorded<Event<Bool>>] = [
-			.error(0, AndTestsError.anyError)
+			.error(0, testError)
 		]
 		XCTAssertEqual(observer.events, correct)
 	}
@@ -109,7 +106,7 @@ class AndTests: XCTestCase {
 			.next(100, true),
 			.next(110, false),
 			.next(120, true),
-			.error(130, AndTestsError.anyError),
+			.error(130, testError),
 			.completed(300)
 			])
 
@@ -130,7 +127,7 @@ class AndTests: XCTestCase {
 			.next(100, true),
 			.next(110, true),
 			.next(120, true),
-			.error(130, AndTestsError.anyError),
+			.error(130, testError),
 			.completed(300)
 			])
 
@@ -139,7 +136,7 @@ class AndTests: XCTestCase {
 		scheduler.start()
 
 		let correct: [Recorded<Event<Bool>>] = [
-			.error(130, AndTestsError.anyError)
+			.error(130, testError)
 		]
 		XCTAssertEqual(observer.events, correct)
 	}
@@ -283,7 +280,7 @@ class AndTests: XCTestCase {
 			])
 		let source3 = scheduler.createColdObservable([
 			.next(75, true),
-			.error(100, AndTestsError.anyError)
+			.error(100, testError)
 			])
 
 		let observer = scheduler.createObserver(Bool.self)
@@ -294,7 +291,7 @@ class AndTests: XCTestCase {
 		scheduler.start()
 
 		let correct: [Recorded<Event<Bool>>] = [
-			.error(100, AndTestsError.anyError)
+			.error(100, testError)
 		]
 		XCTAssertEqual(observer.events, correct)
 	}

--- a/Tests/RxSwift/fromAsyncTests.swift
+++ b/Tests/RxSwift/fromAsyncTests.swift
@@ -76,7 +76,7 @@ class FromAsyncTests: XCTestCase {
 
     func testSingleResultEqualityErrorCase() {
         // given
-        let expectedEvents: [Recorded<Event<String>>] = [.error(0, TestError())]
+        let expectedEvents: [Recorded<Event<String>>] = [.error(0, testError)]
         // when
         _ = Single<String>
             .fromAsync(serviceThrowingError)
@@ -85,10 +85,6 @@ class FromAsyncTests: XCTestCase {
         scheduler.start()
         // then
         XCTAssertEqual(observer.events, expectedEvents)
-    }
-
-    // MARK: - Private utils
-    private struct TestError: Error {
     }
 
     private func service(arg1: String, arg2: Int, completionHandler: (String) -> Void) {
@@ -104,7 +100,7 @@ class FromAsyncTests: XCTestCase {
     }
 
     private func serviceThrowingError(completionHandler: (String?, TestError?) -> Void) {
-        completionHandler(nil, TestError())
+        completionHandler(nil, testError)
     }
 
     private func serviceWithOptionalResult(completionHandler: (String??, TestError?) -> Void) {

--- a/Tests/RxSwift/nwiseTests.swift
+++ b/Tests/RxSwift/nwiseTests.swift
@@ -72,13 +72,13 @@ class NwiseTests: XCTestCase {
         subject.onNext(2)
         subject.onNext(3)
         subject.onNext(4)
-        subject.onError(DummyError.expected)
+        subject.onError(testError)
         scheduler.start()
 
         let correct: [Recorded<Event<EquatableArray<Int>>>] = [
             .next(0, EquatableArray([1, 2, 3])),
             .next(0, EquatableArray([2, 3, 4])),
-            .error(0, DummyError.expected)
+            .error(0, testError)
         ]
 
         XCTAssertEqual(observer.events, correct)
@@ -148,22 +148,18 @@ class NwiseTests: XCTestCase {
         subject.onNext(2)
         subject.onNext(3)
         subject.onNext(4)
-        subject.onError(DummyError.expected)
+        subject.onError(testError)
         scheduler.start()
 
         let correct = Recorded.events([
             .next(0, "1 2"),
             .next(0, "2 3"),
             .next(0, "3 4"),
-            .error(0, DummyError.expected)
+            .error(0, testError)
         ])
 
         XCTAssertEqual(observer.events, correct)
     }
-}
-
-private enum DummyError: Error {
-    case expected
 }
 
 private struct EquatableArray<Element: Equatable>: Equatable {

--- a/Tests/RxSwift/repeatWithBehaviorTests.swift
+++ b/Tests/RxSwift/repeatWithBehaviorTests.swift
@@ -11,10 +11,6 @@ import RxSwift
 import RxSwiftExt
 import RxTest
 
-private enum RepeatTestErrors: Error {
-	case fatalError
-}
-
 class RepeatWithBehaviorTests: XCTestCase {
 	var sampleValues: TestableObservable<Int>!
     var sampleValuesWithError: TestableObservable<Int>!
@@ -33,7 +29,7 @@ class RepeatWithBehaviorTests: XCTestCase {
 
         sampleValuesWithError = scheduler.createColdObservable([
             .next(210, 1),
-            .error(220, RepeatTestErrors.fatalError)
+            .error(220, testError)
             ])
 	}
 
@@ -65,7 +61,7 @@ class RepeatWithBehaviorTests: XCTestCase {
 
     let erroredCorrectValues: [Recorded<Event<Int>>] = [
         .next(210, 1),
-        .error(220, RepeatTestErrors.fatalError)
+        .error(220, testError)
     ]
 
     // MARK: - Immediate repeats

--- a/Tests/RxSwift/retryWithBehaviorTests.swift
+++ b/Tests/RxSwift/retryWithBehaviorTests.swift
@@ -11,10 +11,6 @@ import RxSwift
 import RxSwiftExt
 import RxTest
 
-private enum RepeatTestErrors: Error {
-	case fatalError
-}
-
 class RetryWithBehaviorTests: XCTestCase {
 	var sampleValues: TestableObservable<Int>!
     var sampleValuesImmediateError: TestableObservable<Int>!
@@ -27,7 +23,7 @@ class RetryWithBehaviorTests: XCTestCase {
 		sampleValues = scheduler.createColdObservable([
 			.next(210, 1),
 			.next(220, 2),
-			.error(230, RepeatTestErrors.fatalError),
+			.error(230, testError),
 			.next(240, 3),
 			.next(250, 4),
 			.next(260, 5),
@@ -36,7 +32,7 @@ class RetryWithBehaviorTests: XCTestCase {
 			])
 
         sampleValuesImmediateError = scheduler.createColdObservable([
-            .error(230, RepeatTestErrors.fatalError)
+            .error(230, testError)
             ])
 
         sampleValuesNeverError = scheduler.createColdObservable([
@@ -58,7 +54,7 @@ class RetryWithBehaviorTests: XCTestCase {
 			.next(450, 2),
 			.next(670, 1),
 			.next(680, 2),
-			.error(690, RepeatTestErrors.fatalError)])
+			.error(690, testError)])
 
         let res = scheduler.start(created: 0, subscribed: 0, disposed: 1000) {
 			self.sampleValues.asObservable().retry(.immediate(maxCount: 3), scheduler: self.scheduler)
@@ -69,7 +65,7 @@ class RetryWithBehaviorTests: XCTestCase {
 
     func testImmediateRetryWithoutPredicate_ImmediateError() {
         let correctValues: [Recorded<Event<Int>>] = [
-            .error(690, RepeatTestErrors.fatalError)
+            .error(690, testError)
         ]
 
         let res = scheduler.start(created: 0, subscribed: 0, disposed: 1000) {
@@ -105,7 +101,7 @@ class RetryWithBehaviorTests: XCTestCase {
 			.next(450, 2),
 			.next(670, 1),
 			.next(680, 2),
-			.error(690, RepeatTestErrors.fatalError)])
+			.error(690, testError)])
 
 		// Provide simple predicate that always return true
 		let res = scheduler.start(created: 0, subscribed: 0, disposed: 1000) {
@@ -123,7 +119,7 @@ class RetryWithBehaviorTests: XCTestCase {
             .next(220, 2),
             .next(440, 1),
             .next(450, 2),
-            .error(460, RepeatTestErrors.fatalError)])
+            .error(460, testError)])
 
         // Provide simple predicate that always returns true
         var attempts = 0
@@ -141,7 +137,7 @@ class RetryWithBehaviorTests: XCTestCase {
 		let correctValues = Recorded.events([
 			.next(210, 1),
 			.next(220, 2),
-			.error(230, RepeatTestErrors.fatalError)])
+			.error(230, testError)])
 
 		// Provide simple predicate that always return false (so, sequence will not repeated)
 		let res = scheduler.start(created: 0, subscribed: 0, disposed: 1000) {
@@ -161,7 +157,7 @@ class RetryWithBehaviorTests: XCTestCase {
 			.next(455, 2),
 			.next(680, 1),
 			.next(690, 2),
-			.error(700, RepeatTestErrors.fatalError)])
+			.error(700, testError)])
 
 		let res = scheduler.start(created: 0, subscribed: 0, disposed: 1000) {
 			self.sampleValues.asObservable().retry(.delayed(maxCount: 3, time: 5.0), scheduler: self.scheduler)
@@ -178,7 +174,7 @@ class RetryWithBehaviorTests: XCTestCase {
 			.next(455, 2),
 			.next(680, 1),
 			.next(690, 2),
-			.error(700, RepeatTestErrors.fatalError)])
+			.error(700, testError)])
 
 		let res = scheduler.start(created: 0, subscribed: 0, disposed: 1000) {
 			self.sampleValues.asObservable().retry(.delayed(maxCount: 3, time: 5.0), scheduler: self.scheduler) { _ in
@@ -193,7 +189,7 @@ class RetryWithBehaviorTests: XCTestCase {
 		let correctValues = Recorded.events([
 			.next(210, 1),
 			.next(220, 2),
-			.error(230, RepeatTestErrors.fatalError)])
+			.error(230, testError)])
 
 		let res = scheduler.start(created: 0, subscribed: 0, disposed: 1000) {
 			self.sampleValues.asObservable().retry(.delayed(maxCount: 3, time: 5.0), scheduler: self.scheduler) { _ in
@@ -214,7 +210,7 @@ class RetryWithBehaviorTests: XCTestCase {
 			.next(695, 2),
 			.next(935, 1),
 			.next(945, 2),
-			.error(955, RepeatTestErrors.fatalError)])
+			.error(955, testError)])
 
 		let res = scheduler.start(created: 0, subscribed: 0, disposed: 1000) {
 			self.sampleValues.asObservable().retry(.exponentialDelayed(maxCount: 4, initial: 5.0, multiplier: 1.0), scheduler: self.scheduler)
@@ -233,7 +229,7 @@ class RetryWithBehaviorTests: XCTestCase {
 			.next(695, 2),
 			.next(935, 1),
 			.next(945, 2),
-			.error(955, RepeatTestErrors.fatalError)])
+			.error(955, testError)])
 
 		let res = scheduler.start(created: 0, subscribed: 0, disposed: 1000) {
 			self.sampleValues.asObservable().retry(.exponentialDelayed(maxCount: 4, initial: 5.0, multiplier: 1.0), scheduler: self.scheduler) { _ in
@@ -248,7 +244,7 @@ class RetryWithBehaviorTests: XCTestCase {
 		let correctValues = Recorded.events([
 			.next(210, 1),
 			.next(220, 2),
-			.error(230, RepeatTestErrors.fatalError)])
+			.error(230, testError)])
 
 		let res = scheduler.start(created: 0, subscribed: 0, disposed: 1000) {
 			self.sampleValues.asObservable().retry(.exponentialDelayed(maxCount: 4, initial: 5.0, multiplier: 1.0), scheduler: self.scheduler) { _ in
@@ -271,7 +267,7 @@ class RetryWithBehaviorTests: XCTestCase {
 			.next(1000, 2),
 			.next(1300, 1),
 			.next(1310, 2),
-			.error(1320, RepeatTestErrors.fatalError)])
+			.error(1320, testError)])
 
 		// Custom delay calculator
 		let customCalculator: (UInt) -> DispatchTimeInterval = { attempt in
@@ -302,7 +298,7 @@ class RetryWithBehaviorTests: XCTestCase {
 			.next(1000, 2),
 			.next(1300, 1),
 			.next(1310, 2),
-			.error(1320, RepeatTestErrors.fatalError)])
+			.error(1320, testError)])
 
 		// Custom delay calculator
 		let customCalculator: (UInt) -> DispatchTimeInterval = { attempt in
@@ -327,7 +323,7 @@ class RetryWithBehaviorTests: XCTestCase {
 		let correctValues = Recorded.events([
 			.next(210, 1),
 			.next(220, 2),
-			.error(230, RepeatTestErrors.fatalError)])
+			.error(230, testError)])
 
 		// Custom delay calculator
 		let customCalculator: ((UInt) -> DispatchTimeInterval) = { attempt in


### PR DESCRIPTION
RxSwift main repo use this strategy to avoid countless `private struct MyError: Swift.Error`. We actually need only one test error type for whole project, no need to create own on every class.
In case of complicated error logic (which i can't see now) custom private type can be created