### PR TITLE
Add `mapToResult` Operator

### DIFF
--- a/RxSwiftExt.xcodeproj/project.pbxproj
+++ b/RxSwiftExt.xcodeproj/project.pbxproj
@@ -200,6 +200,9 @@
 		C4D2154420118FBA009804AE /* Observable+OfTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D2154020118F8B009804AE /* Observable+OfTypeTests.swift */; };
 		C4D2154520118FC1009804AE /* ofType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D2153E20118A81009804AE /* ofType.swift */; };
 		C4D2154620118FC1009804AE /* ofType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D2153E20118A81009804AE /* ofType.swift */; };
+		C96AAA2324AB0DF6009BBACE /* MapToResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A870AA24AB03C100E4013B /* MapToResultTests.swift */; };
+		C96AAA2424AB0DF7009BBACE /* MapToResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A870AA24AB03C100E4013B /* MapToResultTests.swift */; };
+		C96AAA2524AB0DF7009BBACE /* MapToResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A870AA24AB03C100E4013B /* MapToResultTests.swift */; };
 		C9ACD7AB24A9B4A000DCBFE3 /* mapToResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9ACD7AA24A9B4A000DCBFE3 /* mapToResult.swift */; };
 		D7C72A3E1FDC5C5D00EAAAAB /* NwiseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C72A3D1FDC5C5D00EAAAAB /* NwiseTests.swift */; };
 		D7C72A3F1FDC5C5D00EAAAAB /* NwiseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C72A3D1FDC5C5D00EAAAAB /* NwiseTests.swift */; };
@@ -385,6 +388,7 @@
 		BF79DA0D206C185B008AA708 /* WithUnretainedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithUnretainedTests.swift; sourceTree = "<group>"; };
 		C4D2153E20118A81009804AE /* ofType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ofType.swift; sourceTree = "<group>"; };
 		C4D2154020118F8B009804AE /* Observable+OfTypeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Observable+OfTypeTests.swift"; sourceTree = "<group>"; };
+		C9A870AA24AB03C100E4013B /* MapToResultTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapToResultTests.swift; sourceTree = "<group>"; };
 		C9ACD7AA24A9B4A000DCBFE3 /* mapToResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = mapToResult.swift; sourceTree = "<group>"; };
 		D7C72A3D1FDC5C5D00EAAAAB /* NwiseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NwiseTests.swift; sourceTree = "<group>"; };
 		D7C72A411FDC5D8F00EAAAAB /* nwise.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = nwise.swift; path = Source/RxSwift/nwise.swift; sourceTree = SOURCE_ROOT; };
@@ -610,6 +614,7 @@
 				58C54E184069446EDEE748F9 /* ZipWithTest.swift */,
 				BF79DA0D206C185B008AA708 /* WithUnretainedTests.swift */,
 				A23E148E21A9F10D00CD5B2F /* PartitionTests.swift */,
+				C9A870AA24AB03C100E4013B /* MapToResultTests.swift */,
 			);
 			name = RxSwift;
 			path = Tests/RxSwift;
@@ -1121,6 +1126,7 @@
 				1A8741AC20745A91004BB762 /* UIViewPropertyAnimatorTests+Rx.swift in Sources */,
 				E62D9D592199D2E3006636D7 /* BufferWithTriggerTests.swift in Sources */,
 				3DBDE5FF1FBBB09900DF47F9 /* AndTests.swift in Sources */,
+				C96AAA2324AB0DF6009BBACE /* MapToResultTests.swift in Sources */,
 				58C545FD1AE234C7F290334F /* ZipWithTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1194,6 +1200,7 @@
 				62512CA01F0EB1850083A89F /* RetryWithBehaviorTests.swift in Sources */,
 				C4D2154320118FB9009804AE /* Observable+OfTypeTests.swift in Sources */,
 				A23E149021A9F10D00CD5B2F /* PartitionTests.swift in Sources */,
+				C96AAA2424AB0DF7009BBACE /* MapToResultTests.swift in Sources */,
 				782485962298A785005CF8CC /* MergeWithTests.swift in Sources */,
 				780CB21E20A0EE8300FD3F39 /* MapManyTests.swift in Sources */,
 				62512C911F0EB17F0083A89F /* NotTests+RxCocoa.swift in Sources */,
@@ -1281,6 +1288,7 @@
 				E39C42061F18B13E007F2ACD /* IgnoreWhenTests.swift in Sources */,
 				C4D2154420118FBA009804AE /* Observable+OfTypeTests.swift in Sources */,
 				A23E149121A9F10D00CD5B2F /* PartitionTests.swift in Sources */,
+				C96AAA2524AB0DF7009BBACE /* MapToResultTests.swift in Sources */,
 				782485972298A785005CF8CC /* MergeWithTests.swift in Sources */,
 				780CB21F20A0EE8300FD3F39 /* MapManyTests.swift in Sources */,
 				E39C420C1F18B13E007F2ACD /* PausableBufferedTests.swift in Sources */,

--- a/RxSwiftExt.xcodeproj/project.pbxproj
+++ b/RxSwiftExt.xcodeproj/project.pbxproj
@@ -200,6 +200,7 @@
 		C4D2154420118FBA009804AE /* Observable+OfTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D2154020118F8B009804AE /* Observable+OfTypeTests.swift */; };
 		C4D2154520118FC1009804AE /* ofType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D2153E20118A81009804AE /* ofType.swift */; };
 		C4D2154620118FC1009804AE /* ofType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D2153E20118A81009804AE /* ofType.swift */; };
+		C9ACD7AB24A9B4A000DCBFE3 /* mapToResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9ACD7AA24A9B4A000DCBFE3 /* mapToResult.swift */; };
 		D7C72A3E1FDC5C5D00EAAAAB /* NwiseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C72A3D1FDC5C5D00EAAAAB /* NwiseTests.swift */; };
 		D7C72A3F1FDC5C5D00EAAAAB /* NwiseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C72A3D1FDC5C5D00EAAAAB /* NwiseTests.swift */; };
 		D7C72A401FDC5C5D00EAAAAB /* NwiseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C72A3D1FDC5C5D00EAAAAB /* NwiseTests.swift */; };
@@ -384,6 +385,7 @@
 		BF79DA0D206C185B008AA708 /* WithUnretainedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithUnretainedTests.swift; sourceTree = "<group>"; };
 		C4D2153E20118A81009804AE /* ofType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ofType.swift; sourceTree = "<group>"; };
 		C4D2154020118F8B009804AE /* Observable+OfTypeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Observable+OfTypeTests.swift"; sourceTree = "<group>"; };
+		C9ACD7AA24A9B4A000DCBFE3 /* mapToResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = mapToResult.swift; sourceTree = "<group>"; };
 		D7C72A3D1FDC5C5D00EAAAAB /* NwiseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NwiseTests.swift; sourceTree = "<group>"; };
 		D7C72A411FDC5D8F00EAAAAB /* nwise.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = nwise.swift; path = Source/RxSwift/nwise.swift; sourceTree = SOURCE_ROOT; };
 		DC612871209E80810053CBB7 /* mapMany.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = mapMany.swift; sourceTree = "<group>"; };
@@ -568,6 +570,7 @@
 				BF79DA09206C145D008AA708 /* withUnretained.swift */,
 				DC612871209E80810053CBB7 /* mapMany.swift */,
 				A23E148621A9EFC000CD5B2F /* partition.swift */,
+				C9ACD7AA24A9B4A000DCBFE3 /* mapToResult.swift */,
 			);
 			path = RxSwift;
 			sourceTree = "<group>";
@@ -1068,6 +1071,7 @@
 				DC612872209E80810053CBB7 /* mapMany.swift in Sources */,
 				5386076F1E6F1C0A000361DE /* mapTo+RxCocoa.swift in Sources */,
 				A23E148B21A9F03600CD5B2F /* partition+RxCocoa.swift in Sources */,
+				C9ACD7AB24A9B4A000DCBFE3 /* mapToResult.swift in Sources */,
 				538607B71E6F334B000361DE /* repeatWithBehavior.swift in Sources */,
 				538607AC1E6F334B000361DE /* catchErrorJustComplete.swift in Sources */,
 				58C5450451345D65DF48F6C5 /* zipWith.swift in Sources */,

--- a/Source/RxSwift/mapToResult.swift
+++ b/Source/RxSwift/mapToResult.swift
@@ -26,7 +26,7 @@ public extension ObservableType {
             return .just(.failure(transformedError))
         }
     }
-    
+
     /**
      Returns an Observable that transformed event (`Element`, `Error`) to element of `Result<Element, Error>`
      
@@ -67,7 +67,7 @@ public extension PrimitiveSequence where Trait == SingleTrait {
         }
         .asSingle()
     }
-    
+
     /**
      Returns an Single that transformed event (`Element`, `Error`) to element of `Result<Element, Error>`
     
@@ -106,7 +106,7 @@ public extension PrimitiveSequence where Trait == MaybeTrait {
         }
         .asMaybe()
     }
-    
+
     /**
      Returns an Maybe that transformed event (`Element`, `Error`) to element of `Result<Element, Error>`
     

--- a/Source/RxSwift/mapToResult.swift
+++ b/Source/RxSwift/mapToResult.swift
@@ -12,11 +12,11 @@ public extension ObservableType {
     /**
      Returns an Observable that transformed event(`Element`, `Error`) to element of `Result<Element, Error>`
     
-     - parameter type: A specific error type, will be `Result.Failure` type (If `type` is different from type of error emitted by Observable, an error occurs)
+     - parameter errorType: A specific error type, will be `Result.Failure` type (If `type` is different from type of error emitted by Observable, an error occurs)
      - parameter catchErrorCastingFailed: Error casting failure handler function, producing another Observable.
      - returns: An Observable which only element of `Result` type is emitted
     */
-    func mapToResult<E: Error>(type: E.Type, catchErrorCastingFailed handler: @escaping (Error) -> Observable<Result<Element, E>>) -> Observable<Result<Element, E>> {
+    func mapToResult<E: Error>(errorType: E.Type, catchErrorCastingFailed handler: @escaping (Error) -> Observable<Result<Element, E>>) -> Observable<Result<Element, E>> {
         self.map { element -> Result<Element, E> in
             return .success(element)
         }.catchError { error -> Observable<Result<Element, E>> in
@@ -30,12 +30,12 @@ public extension ObservableType {
     /**
      Returns an Observable that transformed event (`Element`, `Error`) to element of `Result<Element, Error>`
      
-     - parameter type: A specific error type, will be `Result.Failure` type (If `type` is different from type of error emitted by Observable, an error occurs)
+     - parameter errorType: A specific error type, will be `Result.Failure` type (If `type` is different from type of error emitted by Observable, an error occurs)
      - returns: An Observable which only element of `Result` type is emitted
      */
-    func mapToResult<E: Error>(type: E.Type) -> Observable<Result<Element, E>> {
-        self.mapToResult(type: type) { unexpectedError in
-            assertionFailure("unexpected error is emitted [expected type: \(type)] [emitted type: \(unexpectedError.self)]")
+    func mapToResult<E: Error>(errorType: E.Type) -> Observable<Result<Element, E>> {
+        self.mapToResult(errorType: errorType) { unexpectedError in
+            assertionFailure("unexpected error is emitted [expected type: \(errorType)] [emitted type: \(unexpectedError.self)]")
             return .empty()
         }
     }
@@ -47,7 +47,7 @@ public extension ObservableType {
      - returns: An Observable which only element of `Result` type is emitted
     */
     func mapToResult<E: Error>(catchErrorCastingFailedJustReturn errorValue: E) -> Observable<Result<Element, E>> {
-        self.mapToResult(type: E.self) { _ in
+        self.mapToResult(errorType: E.self) { _ in
             return .just(.failure(errorValue))
         }
     }
@@ -57,12 +57,12 @@ public extension PrimitiveSequence where Trait == SingleTrait {
     /**
      Returns an Single that transformed event(`Element`, `Error`) to element of `Result<Element, Error>`
     
-     - parameter type: A specific error type, will be `Result.Failure` type (If `type` is different from from type of error emitted by Single, an error occurs)
+     - parameter errorType: A specific error type, will be `Result.Failure` type (If `type` is different from from type of error emitted by Single, an error occurs)
      - parameter catchErrorCastingFailed: Error casting failure handler function, producing another Single.
      - returns: An Single which only element of `Result` type is emitted
      */
-    func mapToResult<E: Error>(type: E.Type, catchErrorCastingFailed handler: @escaping (Error) -> Single<Result<Element, E>>) -> Single<Result<Element, E>> {
-        self.asObservable().mapToResult(type: type) { error in
+    func mapToResult<E: Error>(errorType: E.Type, catchErrorCastingFailed handler: @escaping (Error) -> Single<Result<Element, E>>) -> Single<Result<Element, E>> {
+        self.asObservable().mapToResult(errorType: errorType) { error in
             return handler(error).asObservable()
         }
         .asSingle()
@@ -71,12 +71,12 @@ public extension PrimitiveSequence where Trait == SingleTrait {
     /**
      Returns an Single that transformed event (`Element`, `Error`) to element of `Result<Element, Error>`
     
-     - parameter type: A specific error type, will be `Result.Failure` type (If `type` is different from type of error emitted by Single, an error occurs)
+     - parameter errorType: A specific error type, will be `Result.Failure` type (If `type` is different from type of error emitted by Single, an error occurs)
      - returns: An Single which only element of `Result` type is emitted
      */
-    func mapToResult<E: Error>(type: E.Type) -> Single<Result<Element, E>> {
-        self.mapToResult(type: type) { unexpectedError in
-            assertionFailure("unexpected error is emitted [expected type: \(type)] [emitted type: \(unexpectedError.self)]")
+    func mapToResult<E: Error>(errorType: E.Type) -> Single<Result<Element, E>> {
+        self.mapToResult(errorType: errorType) { unexpectedError in
+            assertionFailure("unexpected error is emitted [expected type: \(errorType)] [emitted type: \(unexpectedError.self)]")
             return .never()
         }
     }
@@ -96,12 +96,12 @@ public extension PrimitiveSequence where Trait == MaybeTrait {
     /**
      Returns an Maybe that transformed event(`Element`, `Error`) to element of `Result<Element, Error>`
     
-     - parameter type: A specific error type, will be `Result.Failure` type (If `type` is different from from type of error emitted by Maybe, an error occurs)
+     - parameter errorType: A specific error type, will be `Result.Failure` type (If `type` is different from from type of error emitted by Maybe, an error occurs)
      - parameter catchErrorCastingFailed: Error casting failure handler function, producing another Maybe.
      - returns: An Single which only element of `Result` type is emitted
     */
-    func mapToResult<E: Error>(type: E.Type, catchErrorCastingFailed handler: @escaping (Error) -> Maybe<Result<Element, E>>) -> Maybe<Result<Element, E>> {
-        self.asObservable().mapToResult(type: type) { error in
+    func mapToResult<E: Error>(errorType: E.Type, catchErrorCastingFailed handler: @escaping (Error) -> Maybe<Result<Element, E>>) -> Maybe<Result<Element, E>> {
+        self.asObservable().mapToResult(errorType: errorType) { error in
             return handler(error).asObservable()
         }
         .asMaybe()
@@ -110,11 +110,11 @@ public extension PrimitiveSequence where Trait == MaybeTrait {
     /**
      Returns an Maybe that transformed event (`Element`, `Error`) to element of `Result<Element, Error>`
     
-     - parameter type: A specific error type, will be `Result.Failure` type (If `type` is different from type of error emitted by Maybe, an error occurs)
+     - parameter errorType: A specific error type, will be `Result.Failure` type (If `type` is different from type of error emitted by Maybe, an error occurs)
      - returns: An Maybe which only element of `Result` type is emitted
      */
-    func mapToResult<E: Error>(type: E.Type) -> Maybe<Result<Element, E>> {
-        self.asObservable().mapToResult(type: type).asMaybe()
+    func mapToResult<E: Error>(errorType: E.Type) -> Maybe<Result<Element, E>> {
+        self.asObservable().mapToResult(errorType: errorType).asMaybe()
     }
 
     /**

--- a/Source/RxSwift/mapToResult.swift
+++ b/Source/RxSwift/mapToResult.swift
@@ -1,0 +1,52 @@
+//
+//  mapToResult.swift
+//  RxSwiftExt-iOS
+//
+//  Created by 이병찬 on 2020/06/29.
+//  Copyright © 2020 RxSwiftCommunity. All rights reserved.
+//
+
+import RxSwift
+
+public extension ObservableType {
+    func mapToResult<E: Error>(type: E.Type) -> Observable<Result<Element, E>> {
+        self.map { element -> Result<Element, E> in
+            return .success(element)
+        }.catchError { error -> Observable<Result<Element, E>> in
+            guard let transformedError = error as? E else {
+                assertionFailure("예상한 Error의 타입\(type)과 다른 타입의 Error\(error.self)가 방출되었습니다.")
+                return .never()
+            }
+            return .just(.failure(transformedError))
+        }
+    }
+
+    func mapToResult<E: Error>(catchErrorCastingFailedJustReturn defaultError: E) -> Observable<Result<Element, E>> {
+        self.map { element -> Result<Element, E> in
+            return .success(element)
+        }.catchError { error -> Observable<Result<Element, E>> in
+            let transformedError = (error as? E) ?? defaultError
+            return .just(.failure(transformedError))
+        }
+    }
+}
+
+public extension PrimitiveSequence where Trait == SingleTrait {
+    func mapToResult<E: Error>(type: E.Type) -> Single<Result<Element, E>> {
+        self.asObservable().mapToResult(type: type).asSingle()
+    }
+
+    func mapToResult<E: Error>(catchErrorCastingFailedJustReturn defaultError: E) -> Single<Result<Element, E>> {
+        self.asObservable().mapToResult(catchErrorCastingFailedJustReturn: defaultError).asSingle()
+    }
+}
+
+public extension PrimitiveSequence where Trait == MaybeTrait {
+    func mapToResult<E: Error>(type: E.Type) -> Maybe<Result<Element, E>> {
+        self.asObservable().mapToResult(type: type).asMaybe()
+    }
+
+    func mapToResult<E: Error>(catchErrorCastingFailedJustReturn defaultError: E) -> Maybe<Result<Element, E>> {
+        self.asObservable().mapToResult(catchErrorCastingFailedJustReturn: defaultError).asMaybe()
+    }
+}

--- a/Source/RxSwift/mapToResult.swift
+++ b/Source/RxSwift/mapToResult.swift
@@ -57,7 +57,7 @@ public extension PrimitiveSequence where Trait == SingleTrait {
     /**
      Returns an Single that transformed event(`Element`, `Error`) to element of `Result<Element, Error>`
     
-     - parameter errorType: A specific error type, will be `Result.Failure` type (If `type` is different from from type of error emitted by Single, an error occurs)
+     - parameter errorType: A specific error type, will be `Result.Failure` type (If `type` is different from type of error emitted by Single, an error occurs)
      - parameter catchErrorCastingFailed: Error casting failure handler function, producing another Single.
      - returns: An Single which only element of `Result` type is emitted
      */
@@ -96,7 +96,7 @@ public extension PrimitiveSequence where Trait == MaybeTrait {
     /**
      Returns an Maybe that transformed event(`Element`, `Error`) to element of `Result<Element, Error>`
     
-     - parameter errorType: A specific error type, will be `Result.Failure` type (If `type` is different from from type of error emitted by Maybe, an error occurs)
+     - parameter errorType: A specific error type, will be `Result.Failure` type (If `type` is different from type of error emitted by Maybe, an error occurs)
      - parameter catchErrorCastingFailed: Error casting failure handler function, producing another Maybe.
      - returns: An Single which only element of `Result` type is emitted
     */

--- a/Source/RxSwift/mapToResult.swift
+++ b/Source/RxSwift/mapToResult.swift
@@ -9,44 +9,121 @@
 import RxSwift
 
 public extension ObservableType {
-    func mapToResult<E: Error>(type: E.Type) -> Observable<Result<Element, E>> {
+    /**
+     Returns an Observable that transformed event(`Element`, `Error`) to element of `Result<Element, Error>`
+    
+     - parameter type: A specific error type, will be `Result.Failure` type (If `type` is different from type of error emitted by Observable, an error occurs)
+     - parameter catchErrorCastingFailed: Error casting failure handler function, producing another Observable.
+     - returns: An Observable which only element of `Result` type is emitted
+    */
+    func mapToResult<E: Error>(type: E.Type, catchErrorCastingFailed handler: @escaping (Error) -> Observable<Result<Element, E>>) -> Observable<Result<Element, E>> {
         self.map { element -> Result<Element, E> in
             return .success(element)
         }.catchError { error -> Observable<Result<Element, E>> in
             guard let transformedError = error as? E else {
-                assertionFailure("예상한 Error의 타입\(type)과 다른 타입의 Error\(error.self)가 방출되었습니다.")
-                return .never()
+                return handler(error)
             }
             return .just(.failure(transformedError))
         }
     }
+    
+    /**
+     Returns an Observable that transformed event (`Element`, `Error`) to element of `Result<Element, Error>`
+     
+     - parameter type: A specific error type, will be `Result.Failure` type (If `type` is different from type of error emitted by Observable, an error occurs)
+     - returns: An Observable which only element of `Result` type is emitted
+     */
+    func mapToResult<E: Error>(type: E.Type) -> Observable<Result<Element, E>> {
+        self.mapToResult(type: type) { unexpectedError in
+            assertionFailure("unexpected error is emitted [expected type: \(type)] [emitted type: \(unexpectedError.self)]")
+            return .empty()
+        }
+    }
 
-    func mapToResult<E: Error>(catchErrorCastingFailedJustReturn defaultError: E) -> Observable<Result<Element, E>> {
-        self.map { element -> Result<Element, E> in
-            return .success(element)
-        }.catchError { error -> Observable<Result<Element, E>> in
-            let transformedError = (error as? E) ?? defaultError
-            return .just(.failure(transformedError))
+    /**
+     Returns an Observable that transformed event (`Element`, `Error`) to element of `Result<Element, Error>`
+    
+     - parameter `catchErrorCastingFailedJustReturn`: A specific error value returned in case of error casting failure and after that complete the Observable.
+     - returns: An Observable which only element of `Result` type is emitted
+    */
+    func mapToResult<E: Error>(catchErrorCastingFailedJustReturn errorValue: E) -> Observable<Result<Element, E>> {
+        self.mapToResult(type: E.self) { _ in
+            return .just(.failure(errorValue))
         }
     }
 }
 
 public extension PrimitiveSequence where Trait == SingleTrait {
+    /**
+     Returns an Single that transformed event(`Element`, `Error`) to element of `Result<Element, Error>`
+    
+     - parameter type: A specific error type, will be `Result.Failure` type (If `type` is different from from type of error emitted by Single, an error occurs)
+     - parameter catchErrorCastingFailed: Error casting failure handler function, producing another Single.
+     - returns: An Single which only element of `Result` type is emitted
+     */
+    func mapToResult<E: Error>(type: E.Type, catchErrorCastingFailed handler: @escaping (Error) -> Single<Result<Element, E>>) -> Single<Result<Element, E>> {
+        self.asObservable().mapToResult(type: type) { error in
+            return handler(error).asObservable()
+        }
+        .asSingle()
+    }
+    
+    /**
+     Returns an Single that transformed event (`Element`, `Error`) to element of `Result<Element, Error>`
+    
+     - parameter type: A specific error type, will be `Result.Failure` type (If `type` is different from type of error emitted by Single, an error occurs)
+     - returns: An Single which only element of `Result` type is emitted
+     */
     func mapToResult<E: Error>(type: E.Type) -> Single<Result<Element, E>> {
-        self.asObservable().mapToResult(type: type).asSingle()
+        self.mapToResult(type: type) { unexpectedError in
+            assertionFailure("unexpected error is emitted [expected type: \(type)] [emitted type: \(unexpectedError.self)]")
+            return .never()
+        }
     }
 
-    func mapToResult<E: Error>(catchErrorCastingFailedJustReturn defaultError: E) -> Single<Result<Element, E>> {
-        self.asObservable().mapToResult(catchErrorCastingFailedJustReturn: defaultError).asSingle()
+    /**
+     Returns an Single that transformed event (`Element`, `Error`) to element of `Result<Element, Error>`
+    
+     - parameter `catchErrorCastingFailedJustReturn`: A specific error value returned in case of error casting failure and after that complete the Single.
+     - returns: An Single which only element of `Result` type is emitted
+    */
+    func mapToResult<E: Error>(catchErrorCastingFailedJustReturn errorValue: E) -> Single<Result<Element, E>> {
+        self.asObservable().mapToResult(catchErrorCastingFailedJustReturn: errorValue).asSingle()
     }
 }
 
 public extension PrimitiveSequence where Trait == MaybeTrait {
+    /**
+     Returns an Maybe that transformed event(`Element`, `Error`) to element of `Result<Element, Error>`
+    
+     - parameter type: A specific error type, will be `Result.Failure` type (If `type` is different from from type of error emitted by Maybe, an error occurs)
+     - parameter catchErrorCastingFailed: Error casting failure handler function, producing another Maybe.
+     - returns: An Single which only element of `Result` type is emitted
+    */
+    func mapToResult<E: Error>(type: E.Type, catchErrorCastingFailed handler: @escaping (Error) -> Maybe<Result<Element, E>>) -> Maybe<Result<Element, E>> {
+        self.asObservable().mapToResult(type: type) { error in
+            return handler(error).asObservable()
+        }
+        .asMaybe()
+    }
+    
+    /**
+     Returns an Maybe that transformed event (`Element`, `Error`) to element of `Result<Element, Error>`
+    
+     - parameter type: A specific error type, will be `Result.Failure` type (If `type` is different from type of error emitted by Maybe, an error occurs)
+     - returns: An Maybe which only element of `Result` type is emitted
+     */
     func mapToResult<E: Error>(type: E.Type) -> Maybe<Result<Element, E>> {
         self.asObservable().mapToResult(type: type).asMaybe()
     }
 
-    func mapToResult<E: Error>(catchErrorCastingFailedJustReturn defaultError: E) -> Maybe<Result<Element, E>> {
-        self.asObservable().mapToResult(catchErrorCastingFailedJustReturn: defaultError).asMaybe()
+    /**
+     Returns an Maybe that transformed event (`Element`, `Error`) to element of `Result<Element, Error>`
+    
+     - parameter `catchErrorCastingFailedJustReturn`: A specific error value returned in case of error casting failure and after that complete the Maybe.
+     - returns: An Maybe which only element of `Result` type is emitted
+    */
+    func mapToResult<E: Error>(catchErrorCastingFailedJustReturn errorValue: E) -> Maybe<Result<Element, E>> {
+        self.asObservable().mapToResult(catchErrorCastingFailedJustReturn: errorValue).asMaybe()
     }
 }

--- a/Tests/RxSwift/MapToResultTests.swift
+++ b/Tests/RxSwift/MapToResultTests.swift
@@ -1,0 +1,97 @@
+//
+//  MapToResultTests.swift
+//  RxSwiftExt-iOS
+//
+//  Created by 이병찬 on 2020/06/30.
+//  Copyright © 2020 RxSwiftCommunity. All rights reserved.
+//
+
+import RxSwift
+import RxTest
+import XCTest
+import RxSwiftExt
+
+class MapToResultTests: XCTestCase {
+    private var scheduler = TestScheduler(initialClock: 0)
+
+    override func setUp() {
+        super.setUp()
+        self.scheduler = TestScheduler(initialClock: 0)
+    }
+
+    func testMapToResult_noHandler() {
+        let observable = scheduler.createColdObservable([
+            .next(10, "value1"),
+            .next(20, "value2"),
+            .error(30, CustomError.error)
+        ])
+        let observer = scheduler.createObserver(Result<String, CustomError>.self)
+
+        _ = observable.mapToResult(errorType: CustomError.self).bind(to: observer)
+
+        scheduler.start()
+
+        XCTAssertEqual(observer.events, Recorded.events([
+            .next(10, .success("value1")),
+            .next(20, .success("value2")),
+            .next(30, .failure(CustomError.error)),
+            .completed(30),
+        ]))
+    }
+
+    func testMapToResult_handler() {
+        let observable = scheduler.createColdObservable([
+            .next(10, "value1"),
+            .next(20, "value2"),
+            .error(30, UnexpectedError.error)
+        ])
+        let observer = scheduler.createObserver(Result<String, CustomError>.self)
+
+        _ = observable.mapToResult(errorType: CustomError.self) { unexpectedError in
+            if case UnexpectedError.error = unexpectedError {
+                XCTAssert(true)
+            }
+            return .just(.failure(CustomError.error))
+        }
+        .bind(to: observer)
+
+        scheduler.start()
+
+        XCTAssertEqual(observer.events, Recorded.events([
+            .next(10, .success("value1")),
+            .next(20, .success("value2")),
+            .next(30, .failure(CustomError.error)),
+            .completed(30),
+        ]))
+    }
+
+    func testMapToResult_justReturn() {
+        let observable = scheduler.createColdObservable([
+            .next(10, "value1"),
+            .next(20, "value2"),
+            .error(30, UnexpectedError.error)
+        ])
+        let observer = scheduler.createObserver(Result<String, CustomError>.self)
+
+        _ = observable
+            .mapToResult(catchErrorCastingFailedJustReturn: CustomError.error)
+            .bind(to: observer)
+
+        scheduler.start()
+
+        XCTAssertEqual(observer.events, Recorded.events([
+            .next(10, .success("value1")),
+            .next(20, .success("value2")),
+            .next(30, .failure(CustomError.error)),
+            .completed(30),
+        ]))
+    }
+}
+
+private enum CustomError: Error {
+    case error
+}
+
+private enum UnexpectedError: Error {
+    case error
+}

--- a/Tests/RxSwift/MergeWithTests.swift
+++ b/Tests/RxSwift/MergeWithTests.swift
@@ -10,7 +10,6 @@ import XCTest
 import RxSwift
 import RxTest
 
-
 class MergeWithTests: XCTestCase {
     fileprivate func runAndObserve<T>(_ sequence: Observable<T>) -> TestableObserver<T> {
         let scheduler = TestScheduler(initialClock: 0)

--- a/Tests/RxSwift/andTests.swift
+++ b/Tests/RxSwift/andTests.swift
@@ -10,7 +10,6 @@ import XCTest
 import RxSwift
 import RxTest
 
-
 class AndTests: XCTestCase {
 	fileprivate func runAndObserve(_ sequence: Maybe<Bool>) -> TestableObserver<Bool> {
 		let scheduler = TestScheduler(initialClock: 0)


### PR DESCRIPTION
Hello 👋  
I want to add `mapToResult` operator
`mapToResult` operator is transform Observable’s event (`Element`, `Error`) to element of `Result<Element, Error>`
If we use `Result` as Observable’s `Element`, we can solve two problems.

**Problem 1**
The type of error emitted by Observable is Swift.Error.
Therefore, we add unnecessary error statements. ex) `case default`

**Solution 1**
`Result` can specify that Observable only emits certain error type.
So we don’t have to add unnecessary error statements.

**Problem 1** 
When emitted error by Observable, that was died (even HotObservable)
```
// `requestButtonTapped` is HotObservable
// `weatherInfo` dies when `requestWeatherInfo` stream emit Error
let weatherInfo = requestButtonTapped
  .flatMapLatest { NetworkAPI.requestWeatherInfo() }
  .share()  
```

**Solution 2**
If Observable emit `Result.failure` instead of error, we can deal with errors without completion of Observable.
```
// `requestButtonTapped` is HotObservable
// `weatherInfo` never die when `requestWeatherInfo` stream emit Error
let weatherInfo = requestButtonTapped
  .flatMapLatest {
    NetworkAPI.requestWeatherInfo().mapToResult(~)
  }
  .do(onNext: { result in
    if case .failure(let error) = result {
        Log(error)
    }
  })
  .share()  
```

Many Library use `Result` (Alamofire, Maya, Combine…), so I’m sure `mapToResult` Operator will be very useful in RxSwift.
Give me your useful opinion, Thanks you.