### PR TITLE
distinct:  use filter instead of flatMap #trivial

### DIFF
--- a/Source/RxCocoa/distinct+RxCocoa.swift
+++ b/Source/RxCocoa/distinct+RxCocoa.swift
@@ -20,7 +20,7 @@ extension SharedSequence {
         var cache = [Element]()
 
         return filter { element -> Bool in
-            let emitted = try cache.contains(where: predicate)
+            let emitted = cache.contains(where: predicate)
             if !emitted { cache.append(element) }
             return !emitted
         }

--- a/Source/RxCocoa/distinct+RxCocoa.swift
+++ b/Source/RxCocoa/distinct+RxCocoa.swift
@@ -19,14 +19,10 @@ extension SharedSequence {
     public func distinct(_ predicate: @escaping (Element) -> Bool) -> SharedSequence<SharingStrategy, Element> {
         var cache = [Element]()
 
-        return flatMap { element -> SharedSequence<SharingStrategy, Element> in
-            if cache.contains(where: predicate) {
-                return SharedSequence<SharingStrategy, Element>.empty()
-            } else {
-                cache.append(element)
-
-                return SharedSequence<SharingStrategy, Element>.just(element)
-            }
+        return filter { element -> Bool in
+            let emitted = try cache.contains(where: predicate)
+            if !emitted { cache.append(element) }
+            return !emitted
         }
     }
 }
@@ -40,14 +36,10 @@ extension SharedSequence where Element: Equatable {
     public func distinct() -> SharedSequence<SharingStrategy, Element> {
         var cache = [Element]()
 
-        return flatMap { element -> SharedSequence<SharingStrategy, Element> in
-            if cache.contains(element) {
-                return SharedSequence<SharingStrategy, Element>.empty()
-            } else {
-                cache.append(element)
-
-                return SharedSequence<SharingStrategy, Element>.just(element)
-            }
+        return filter { element -> Bool in
+            let emitted = cache.contains(element)
+            if !emitted { cache.append(element) }
+            return !emitted
         }
     }
 }

--- a/Source/RxSwift/distinct.swift
+++ b/Source/RxSwift/distinct.swift
@@ -19,13 +19,10 @@ extension Observable {
      */
     public func distinct(_ predicate: @escaping (Element) throws -> Bool) -> Observable<Element> {
         var cache = [Element]()
-        return compactMap { element -> Element? in
-            if try cache.contains(where: predicate) {
-                return nil
-            } else {
-                cache.append(element)
-                return element
-            }
+        return filter { element -> Bool in
+            let emitted = try cache.contains(where: predicate)
+            if !emitted { cache.append(element) }
+            return !emitted
         }
     }
 }
@@ -38,14 +35,7 @@ extension Observable where Element: Hashable {
      */
     public func distinct() -> Observable<Element> {
         var cache = Set<Element>()
-        return compactMap { element -> Element? in
-            if cache.contains(element) {
-                return nil
-            } else {
-                cache.insert(element)
-                return element
-            }
-        }
+        return filter { element in cache.insert(element).inserted }
     }
 }
 
@@ -57,13 +47,10 @@ extension Observable where Element: Equatable {
      */
     public func distinct() -> Observable<Element> {
         var cache = [Element]()
-        return compactMap { element -> Element? in
-            if cache.contains(element) {
-                return nil
-            } else {
-                cache.append(element)
-                return element
-            }
+        return filter { element -> Bool in
+            let emitted = cache.contains(element)
+            if !emitted { cache.append(element) }
+            return !emitted
         }
     }
 }

--- a/Source/RxSwift/distinct.swift
+++ b/Source/RxSwift/distinct.swift
@@ -19,12 +19,12 @@ extension Observable {
      */
     public func distinct(_ predicate: @escaping (Element) throws -> Bool) -> Observable<Element> {
         var cache = [Element]()
-        return flatMap { element -> Observable<Element> in
+        return compactMap { element -> Element? in
             if try cache.contains(where: predicate) {
-                return Observable<Element>.empty()
+                return nil
             } else {
                 cache.append(element)
-                return Observable<Element>.just(element)
+                return element
             }
         }
     }
@@ -38,12 +38,12 @@ extension Observable where Element: Hashable {
      */
     public func distinct() -> Observable<Element> {
         var cache = Set<Element>()
-        return flatMap { element -> Observable<Element> in
+        return compactMap { element -> Element? in
             if cache.contains(element) {
-                return Observable<Element>.empty()
+                return nil
             } else {
                 cache.insert(element)
-                return Observable<Element>.just(element)
+                return element
             }
         }
     }
@@ -57,12 +57,12 @@ extension Observable where Element: Equatable {
      */
     public func distinct() -> Observable<Element> {
         var cache = [Element]()
-        return flatMap { element -> Observable<Element> in
+        return flatMap { element -> Element? in
             if cache.contains(element) {
-                return Observable<Element>.empty()
+                return nil
             } else {
                 cache.append(element)
-                return Observable<Element>.just(element)
+                return element
             }
         }
     }

--- a/Source/RxSwift/distinct.swift
+++ b/Source/RxSwift/distinct.swift
@@ -57,7 +57,7 @@ extension Observable where Element: Equatable {
      */
     public func distinct() -> Observable<Element> {
         var cache = [Element]()
-        return flatMap { element -> Element? in
+        return compactMap { element -> Element? in
             if cache.contains(element) {
                 return nil
             } else {


### PR DESCRIPTION
I think we can replace `flatMap` by `compactMap` for better performance in `distinct.swift`, without adding anything to the Changelog.