### PR TITLE
Fix Carthage integration

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReactiveX/RxSwift" "~> 6.0"
+github "ReactiveX/RxSwift" ~> 6.0

--- a/RxSwiftExt.xcodeproj/project.pbxproj
+++ b/RxSwiftExt.xcodeproj/project.pbxproj
@@ -24,24 +24,24 @@
 /* Begin PBXBuildFile section */
 		05A2BBB0247DAD2A007B54D6 /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 05A2BBAF247DAD2A007B54D6 /* RxCocoa.framework */; };
 		05A2BBB4247DB0B8007B54D6 /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 05A2BBB3247DB0B8007B54D6 /* RxCocoa.framework */; };
+		074B9D2B2642A8EA009699A3 /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 074B9CF72642A223009699A3 /* RxCocoa.framework */; };
+		074B9D2C2642A8EB009699A3 /* RxRelay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 074B9CF92642A223009699A3 /* RxRelay.framework */; };
+		074B9D2D2642A8EB009699A3 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 074B9CF52642A223009699A3 /* RxSwift.framework */; };
 		0D4D8D3E25CB005800C6971D /* RxSwift.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 62512C581F0EAED20083A89F /* RxSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		0D4D8D3F25CB005800C6971D /* RxTest.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 62512CA61F0EB1BD0083A89F /* RxTest.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		0D4D8D4C25CB079A00C6971D /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 05A2BBAF247DAD2A007B54D6 /* RxCocoa.framework */; };
 		0D4D8D4D25CB079D00C6971D /* RxCocoa.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 05A2BBAF247DAD2A007B54D6 /* RxCocoa.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		0D4D8D5425CB07A300C6971D /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 05A2BBB3247DB0B8007B54D6 /* RxCocoa.framework */; };
 		0D4D8D5B25CB07AE00C6971D /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1AA8395A207451D5001C49ED /* RxCocoa.framework */; };
-		0D4D8D6F25CB0B1700C6971D /* RxRelay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0D4D8D6E25CB0B1700C6971D /* RxRelay.framework */; };
 		0D4D8D7025CB0B1700C6971D /* RxRelay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0D4D8D6E25CB0B1700C6971D /* RxRelay.framework */; };
 		0D4D8D7225CB0B2F00C6971D /* RxRelay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0D4D8D7125CB0B2F00C6971D /* RxRelay.framework */; };
 		0D4D8D7325CB0B2F00C6971D /* RxRelay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0D4D8D7125CB0B2F00C6971D /* RxRelay.framework */; };
 		0D4D8D7425CB0B3F00C6971D /* RxRelay.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0D4D8D7125CB0B2F00C6971D /* RxRelay.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		0D4D8D7C25CB0B4E00C6971D /* RxRelay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0D4D8D7B25CB0B4E00C6971D /* RxRelay.framework */; };
 		0D4D8D7D25CB0B4E00C6971D /* RxRelay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0D4D8D7B25CB0B4E00C6971D /* RxRelay.framework */; };
-		188C6DA31C47B4240092101A /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 188C6DA21C47B4240092101A /* RxSwift.framework */; };
 		1958B5F1216768D900CAF1D3 /* unwrap+SharedSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1958B5F0216768D900CAF1D3 /* unwrap+SharedSequence.swift */; };
 		1958B5F621676ECB00CAF1D3 /* unrwapTests+SharedSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1958B5F521676ECB00CAF1D3 /* unrwapTests+SharedSequence.swift */; };
 		1A8741AC20745A91004BB762 /* UIViewPropertyAnimatorTests+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A8741AB20745A91004BB762 /* UIViewPropertyAnimatorTests+Rx.swift */; };
-		1AA8395B207451D6001C49ED /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1AA8395A207451D5001C49ED /* RxCocoa.framework */; };
 		3D11958B1FCAD9AE0095134B /* and.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DBDE5FB1FBBAE3900DF47F9 /* and.swift */; };
 		3D11958C1FCAD9AF0095134B /* and.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DBDE5FB1FBBAE3900DF47F9 /* and.swift */; };
 		3D638DEC1DC2B2D50089A590 /* RxSwiftExt.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 188C6D911C47B2B20092101A /* RxSwiftExt.framework */; };
@@ -495,9 +495,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1AA8395B207451D6001C49ED /* RxCocoa.framework in Frameworks */,
-				188C6DA31C47B4240092101A /* RxSwift.framework in Frameworks */,
-				0D4D8D6F25CB0B1700C6971D /* RxRelay.framework in Frameworks */,
+				074B9D2D2642A8EB009699A3 /* RxSwift.framework in Frameworks */,
+				074B9D2B2642A8EA009699A3 /* RxCocoa.framework in Frameworks */,
+				074B9D2C2642A8EB009699A3 /* RxRelay.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RxSwiftExt.xcodeproj/project.pbxproj
+++ b/RxSwiftExt.xcodeproj/project.pbxproj
@@ -272,6 +272,76 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		074B9CF42642A223009699A3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 074B9CE72642A222009699A3 /* Rx.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = C8A56AD71AD7424700B4673B;
+			remoteInfo = RxSwift;
+		};
+		074B9CF62642A223009699A3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 074B9CE72642A222009699A3 /* Rx.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = C809396D1B8A71760088E94D;
+			remoteInfo = RxCocoa;
+		};
+		074B9CF82642A223009699A3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 074B9CE72642A222009699A3 /* Rx.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = A2897D53225CA1E7004EA481;
+			remoteInfo = RxRelay;
+		};
+		074B9CFA2642A223009699A3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 074B9CE72642A222009699A3 /* Rx.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = C8093BC71B8A71F00088E94D;
+			remoteInfo = RxBlocking;
+		};
+		074B9CFC2642A223009699A3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 074B9CE72642A222009699A3 /* Rx.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = C88FA50C1C25C44800CCFEA4;
+			remoteInfo = RxTest;
+		};
+		074B9CFE2642A223009699A3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 074B9CE72642A222009699A3 /* Rx.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = C83508C31C386F6F0027C24C;
+			remoteInfo = "AllTests-iOS";
+		};
+		074B9D002642A223009699A3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 074B9CE72642A222009699A3 /* Rx.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = C83509841C38740E0027C24C;
+			remoteInfo = "AllTests-tvOS";
+		};
+		074B9D022642A223009699A3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 074B9CE72642A222009699A3 /* Rx.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = C83509941C38742C0027C24C;
+			remoteInfo = "AllTests-macOS";
+		};
+		074B9D042642A223009699A3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 074B9CE72642A222009699A3 /* Rx.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = C85BA04B1C3878740075D68E;
+			remoteInfo = Microoptimizations;
+		};
+		074B9D062642A223009699A3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 074B9CE72642A222009699A3 /* Rx.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = C8E8BA551E2C181A00A4AC2C;
+			remoteInfo = Benchmarks;
+		};
 		3D638DED1DC2B2D50089A590 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 18EE7A101C47B12F00C7256C /* Project object */;
@@ -321,6 +391,7 @@
 /* Begin PBXFileReference section */
 		05A2BBAF247DAD2A007B54D6 /* RxCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxCocoa.framework; path = Carthage/Build/Mac/RxCocoa.framework; sourceTree = "<group>"; };
 		05A2BBB3247DB0B8007B54D6 /* RxCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxCocoa.framework; path = Carthage/Build/tvOS/RxCocoa.framework; sourceTree = "<group>"; };
+		074B9CE72642A222009699A3 /* Rx.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Rx.xcodeproj; path = Carthage/Checkouts/RxSwift/Rx.xcodeproj; sourceTree = "<group>"; };
 		0D4D8D6E25CB0B1700C6971D /* RxRelay.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxRelay.framework; path = Carthage/Build/iOS/RxRelay.framework; sourceTree = "<group>"; };
 		0D4D8D7125CB0B2F00C6971D /* RxRelay.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxRelay.framework; path = Carthage/Build/Mac/RxRelay.framework; sourceTree = "<group>"; };
 		0D4D8D7B25CB0B4E00C6971D /* RxRelay.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxRelay.framework; path = Carthage/Build/tvOS/RxRelay.framework; sourceTree = "<group>"; };
@@ -489,6 +560,23 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		074B9CE82642A222009699A3 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				074B9CF52642A223009699A3 /* RxSwift.framework */,
+				074B9CF72642A223009699A3 /* RxCocoa.framework */,
+				074B9CF92642A223009699A3 /* RxRelay.framework */,
+				074B9CFB2642A223009699A3 /* RxBlocking.framework */,
+				074B9CFD2642A223009699A3 /* RxTest.framework */,
+				074B9CFF2642A223009699A3 /* AllTests-iOS.xctest */,
+				074B9D012642A223009699A3 /* AllTests-tvOS.xctest */,
+				074B9D032642A223009699A3 /* AllTests-macOS.xctest */,
+				074B9D052642A223009699A3 /* PerformanceTests.app */,
+				074B9D072642A223009699A3 /* Benchmarks.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		188C6D921C47B2B20092101A /* Sources */ = {
 			isa = PBXGroup;
 			children = (
@@ -504,6 +592,7 @@
 		18EE7A0F1C47B12F00C7256C = {
 			isa = PBXGroup;
 			children = (
+				074B9CE72642A222009699A3 /* Rx.xcodeproj */,
 				781C53FD23122554005CB85A /* Package.swift */,
 				188C6D921C47B2B20092101A /* Sources */,
 				3D638DF21DC2B2EE0089A590 /* Tests */,
@@ -891,6 +980,12 @@
 			mainGroup = 18EE7A0F1C47B12F00C7256C;
 			productRefGroup = 18EE7A191C47B12F00C7256C /* Products */;
 			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 074B9CE82642A222009699A3 /* Products */;
+					ProjectRef = 074B9CE72642A222009699A3 /* Rx.xcodeproj */;
+				},
+			);
 			projectRoot = "";
 			targets = (
 				188C6D901C47B2B20092101A /* RxSwiftExt-iOS */,
@@ -903,6 +998,80 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		074B9CF52642A223009699A3 /* RxSwift.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = RxSwift.framework;
+			remoteRef = 074B9CF42642A223009699A3 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		074B9CF72642A223009699A3 /* RxCocoa.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = RxCocoa.framework;
+			remoteRef = 074B9CF62642A223009699A3 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		074B9CF92642A223009699A3 /* RxRelay.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = RxRelay.framework;
+			remoteRef = 074B9CF82642A223009699A3 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		074B9CFB2642A223009699A3 /* RxBlocking.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = RxBlocking.framework;
+			remoteRef = 074B9CFA2642A223009699A3 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		074B9CFD2642A223009699A3 /* RxTest.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = RxTest.framework;
+			remoteRef = 074B9CFC2642A223009699A3 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		074B9CFF2642A223009699A3 /* AllTests-iOS.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = "AllTests-iOS.xctest";
+			remoteRef = 074B9CFE2642A223009699A3 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		074B9D012642A223009699A3 /* AllTests-tvOS.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = "AllTests-tvOS.xctest";
+			remoteRef = 074B9D002642A223009699A3 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		074B9D032642A223009699A3 /* AllTests-macOS.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = "AllTests-macOS.xctest";
+			remoteRef = 074B9D022642A223009699A3 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		074B9D052642A223009699A3 /* PerformanceTests.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			name = PerformanceTests.app;
+			path = Microoptimizations.app;
+			remoteRef = 074B9D042642A223009699A3 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		074B9D072642A223009699A3 /* Benchmarks.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = Benchmarks.xctest;
+			remoteRef = 074B9D062642A223009699A3 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		188C6D8F1C47B2B20092101A /* Resources */ = {
@@ -1349,7 +1518,7 @@
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.RxSwiftCommunity.RxSwiftExt;
 				PRODUCT_NAME = RxSwiftExt;
@@ -1380,7 +1549,7 @@
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.RxSwiftCommunity.RxSwiftExt;
 				PRODUCT_NAME = RxSwiftExt;
@@ -1438,7 +1607,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -1487,7 +1656,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";


### PR DESCRIPTION
## Motivation

I'd like to use this library with Carthage, However, some settings are broken, so we can't build this with Carthage.

There are two problems.

- We can't use this library with Carthage regularly
- We can't use this library with Carthage in XCFramework

### Minimum situation

Xcode 12.4

#### Cartfile (of an application project)

```
github "RxSwiftCommunity/RxSwiftExt" "7cae93b7795fb7b4ecf617aec5f1c0f1fc8fb0e6" # current main HEAD
```

#### Carthage build command

```console
$ carthage bootstrap --platform ios --use-xcframeworks --cache-builds
*** Building scheme "RxSwiftExt-iOS" in RxSwiftExt.xcworkspace
Build Failed
        Task failed with exit code 65:
        /usr/bin/xcrun xcodebuild -workspace /Users/giginet/work/CarthagePlayground/Carthage/Checkouts/RxSwiftExt/RxSwiftExt.xcworkspace -scheme RxSwiftExt-iOS -configuration Release -derivedDataPath /Users/giginet/Library/Caches/org.carthage.CarthageKit/DerivedData/12.4_12D4e/RxSwiftExt/6.0.0 -sdk iphoneos ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= CARTHAGE=YES archive VALIDATE_WORKSPACE=NO -archivePath /var/folders/b_/_ndwwrsd68q8yskc_sbtlbk80000gn/T/RxSwiftExt SKIP_INSTALL=YES GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=NO CLANG_ENABLE_CODE_COVERAGE=NO STRIP_INSTALLED_PRODUCT=NO (launched in /Users/giginet/work/CarthagePlayground/Carthage/Checkouts/RxSwiftExt)
```

## Description

I fixed some errors to integrate this library with Carthage.

1. `Cartfile` syntax was broken
2. Change minimum development target version to 9.0
    - `Package.swift` requires 9.0. However, xcodeproj's one was wrong.
3. Add `Rx.xcodeproj` to xcodeproj to solve dependencies

Fixes 3 will solve the issue which it can't build this library as XCFramework with Carthage.
[Current xcodeproj](https://github.com/RxSwiftCommunity/RxSwiftExt/blob/7cae93b7795fb7b4ecf617aec5f1c0f1fc8fb0e6/RxSwiftExt.xcodeproj/project.pbxproj) searches`RxSwift.framework` in `Carthage/Build/iOS`.
However, when it was built with `--use-xcframework` options, `RxSwift.xcframework` is generated instead.
So the project can't find dependencies.
I added `Rx.xcodeproj` into the xcodeproj as a child project. It will solve this problem.

