### PR TITLE
Added RxSwift submodule dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Carthage/Checkouts/RxSwift"]
+	path = Carthage/Checkouts/RxSwift
+	url = https://github.com/ReactiveX/RxSwift.git


### PR DESCRIPTION
There is a reference to Rx.xcodeproj in the project, and without this it does not build if you don't use Carthage.

It's essentially the same fix as https://github.com/RxSwiftCommunity/RxDataSources/commit/98ae6d937f37766187f97cd066076fa7127cff01