### PR TITLE
Update podspec version to match release

### DIFF
--- a/RxSwiftExt.podspec
+++ b/RxSwiftExt.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "RxSwiftExt"
-  s.version      = "6.0.1"
+  s.version      = "6.1.0"
   s.summary      = "RxSwift operators not found in the core distribtion"
   s.description  = <<-DESC
     A collection of operators for RxSwift adding commonly requested operations not found in the core distribution


### PR DESCRIPTION
After 6.1.0 release was created, the .podspec file was not update, so you are unable to use 6.1.0 in your Podfile.